### PR TITLE
Implement api/v2/torrents/files endpoint

### DIFF
--- a/server/RdtClient.Service/Models/QBittorrent/TorrentFileItem.cs
+++ b/server/RdtClient.Service/Models/QBittorrent/TorrentFileItem.cs
@@ -1,0 +1,11 @@
+using System;
+using Newtonsoft.Json;
+
+namespace RdtClient.Service.Models.QBittorrent
+{
+    public class TorrentFileItem
+    {
+        [JsonProperty("name")]
+        public String Name { get; set; }
+    }
+}

--- a/server/RdtClient.Service/Services/QBittorrent.cs
+++ b/server/RdtClient.Service/Services/QBittorrent.cs
@@ -16,6 +16,7 @@ namespace RdtClient.Service.Services
         Task<AppPreferences> AppPreferences();
         Task<String> AppDefaultSavePath();
         Task<IList<TorrentInfo>> TorrentInfo();
+        Task<IList<TorrentFileItem>> TorrentFileContents(String hash);
         Task<TorrentProperties> TorrentProperties(String hash);
         Task TorrentsDelete(String hash, Boolean deleteFiles);
         Task TorrentsAdd(String magnetLink, Boolean autoDownload, Boolean autoDelete);
@@ -285,6 +286,26 @@ namespace RdtClient.Service.Services
                     _ => throw new ArgumentOutOfRangeException()
                 };
 
+                results.Add(result);
+            }
+
+            return results;
+        }
+        public async Task<IList<TorrentFileItem>> TorrentFileContents(String hash)
+        {
+            var results = new List<TorrentFileItem>();
+
+            var torrent = await _torrents.GetByHash(hash);
+
+            if (torrent == null)
+            {
+                return null;
+            }
+
+            foreach (var file in torrent.Files)
+            {
+                var result = new TorrentFileItem();
+                result.Name = file.Path;
                 results.Add(result);
             }
 

--- a/server/RdtClient.Web/Controllers/QBittorrentController.cs
+++ b/server/RdtClient.Web/Controllers/QBittorrentController.cs
@@ -139,7 +139,30 @@ namespace RdtClient.Web.Controllers
             var result = await _qBittorrent.TorrentInfo();
             return Ok(result);
         }
-        
+
+        [Authorize]
+        [Route("torrents/files")]
+        [HttpGet]
+        public async Task<ActionResult<IList<TorrentFileItem>>> TorrentsFiles([FromQuery] QBTorrentsHashRequest request)
+        {
+            var result = await _qBittorrent.TorrentFileContents(request.Hash);
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(result);
+        }
+
+        [Authorize]
+        [Route("torrents/files")]
+        [HttpPost]
+        public async Task<ActionResult<IList<TorrentFileItem>>> TorrentsFilesPost([FromForm] QBTorrentsHashRequest request)
+        {
+            return await TorrentsFiles(request);
+        }
+
         [Authorize]
         [Route("torrents/properties")]
         [HttpGet]


### PR DESCRIPTION
It seems that recently sonarr and radarr have [changed the qbittorrent integration](https://github.com/Sonarr/Sonarr/commit/813f8869202b54048db8d792ee6c3f0d060dbd72#diff-4aa480003e8ce16bee777a84e906e71a29f45c4d6ea7c25bdbb2080795c36460R229) such that this endpoint is required for file mapping to work (and prevent a fatal error).

I've tested this api works with both sonarr and radarr.

Also thanks for creating this project!

