### PR TITLE
Updated docker file to leverage linuxserver/baseimage-mono which uses s6-overlay and has support for running under custom PUID and PGID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM ghcr.io/linuxserver/baseimage-mono:LTS
 ARG BUILD_DATE
 ARG VERSION
 ARG RDTCLIENT_VERSION
+ARG DOTNET_VERSION=5.0
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="ravensorb"
 
@@ -22,7 +23,7 @@ RUN mkdir /app || true && ln -s /config /data && mkdir -p /data/downloads /data/
       dpkg -i packages-microsoft-prod.deb 2> /dev/null && \
       rm packages-microsoft-prod.deb && \
       apt update -y -qq && \
-      apt install -y -qq apt-transport-https dotnet-runtime-5.0 aspnetcore-runtime-5.0 && \
+      apt install -y -qq apt-transport-https dotnet-runtime-${DOTNET_VERSION} aspnetcore-runtime-${DOTNET_VERSION} && \
     echo "**** install rtd-client ****" && \
       if [ -z ${RDTCLIENT_VERSION+x} ]; then \
          RDTCLIENT_VERSION=$(curl -sX GET https://api.github.com/repos/rogerfar/rdt-client/releases/latest | jq -r ".name"); \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,48 @@
-# Stage 1 - Build the frontend
-FROM amd64/node:15.5-buster AS node-build-env
+# Stage 1 - Build runtime image
+FROM ghcr.io/linuxserver/baseimage-mono:LTS
 
-RUN mkdir /appclient
-WORKDIR /appclient
+# set version label
+ARG BUILD_DATE
+ARG VERSION
+ARG RDTCLIENT_VERSION
+LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
+LABEL maintainer="ravensorb"
 
-COPY client/. .
-RUN npm ci
-RUN npx ng build --prod --output-path=out
+# set environment variables
+ARG DEBIAN_FRONTEND="noninteractive"
+ENV XDG_CONFIG_HOME="/config/xdg"
 
-# Stage 2 - Build the backend
-FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.13-amd64 AS dotnet-build-env
+RUN mkdir /app || true && ln -s /config /data && mkdir -p /data/downloads /data/db || true && \
+    echo "**** Updating package information ****" && \ 
+      apt update -y -qq && \
+    echo "**** install packages ****" && \
+      apt install -y -qq wget jq && \
+    echo "**** Installing dotnet ****" && \
+      wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb  && \
+      dpkg -i packages-microsoft-prod.deb 2> /dev/null && \
+      rm packages-microsoft-prod.deb && \
+      apt update -y -qq && \
+      apt install -y -qq apt-transport-https dotnet-runtime-5.0 aspnetcore-runtime-5.0 && \
+    echo "**** install rtd-client ****" && \
+      if [ -z ${RDTCLIENT_VERSION+x} ]; then \
+         RDTCLIENT_VERSION=$(curl -sX GET https://api.github.com/repos/rogerfar/rdt-client/releases/latest | jq -r ".name"); \
+      fi && \
+      curl -o \
+         /tmp/RealDebridClient.zip -L \
+         "https://github.com/rogerfar/rdt-client/releases/download/${RDTCLIENT_VERSION}/RealDebridClient.zip" && \
+      unzip /tmp/RealDebridClient.zip -d /app && \
+    echo "**** cleanup ****" && \
+      apt-get -y -qq -o Dpkg::Use-Pty=0 clean && apt-get -y -qq -o Dpkg::Use-Pty=0 purge && \
+      rm -rf \
+         /tmp/* \
+         /var/lib/apt/lists/* \
+         /var/tmp/* || true
 
-RUN mkdir /appserver
-WORKDIR /appserver
+WORKDIR /data
 
-COPY server/. .
+# add local files
+COPY root/ /
 
-RUN if [ "$BUILDPLATFORM" = "arm/v7" ] ; then dotnet restore -r linux-arm RdtClient.sln ; else dotnet restore RdtClient.sln ; fi
-RUN if [ "$BUILDPLATFORM" = "arm/v7" ] ; then dotnet publish -r linux-arm -c Release -o out ; else dotnet publish -c Release -o out ; fi
-
-# Stage 3 - Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.3-buster-slim AS base
-
-RUN addgroup --quiet --gid 1000 dotnet
-RUN adduser --system --uid 1000 --group dotnet --shell /bin/sh
-
-RUN mkdir /app
-
-WORKDIR /app
-COPY --from=dotnet-build-env /appserver/out .
-COPY --from=node-build-env /appclient/out ./wwwroot
-
-RUN chown -R dotnet:dotnet /app
-
-USER 1000
-
-ENTRYPOINT ["dotnet", "RdtClient.Web.dll"]
+# ports and volumes
+EXPOSE 6500
+VOLUME ["/config", "/data" ]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,71 @@
+# Stage 1 - Build the frontend
+FROM amd64/node:15.5-buster AS node-build-env
+
+RUN mkdir /appclient
+WORKDIR /appclient
+
+RUN \
+   git clone https://github.com/rogerfar/rdt-client.git . && \
+   cd client && \
+   npm ci && \
+   npx ng build --prod --output-path=out
+
+# Stage 2 - Build the backend
+FROM mcr.microsoft.com/dotnet/sdk:5.0.103-alpine3.13-amd64 AS dotnet-build-env
+
+RUN mkdir /appserver
+WORKDIR /appserver
+
+RUN \
+   git clone https://github.com/rogerfar/rdt-client.git . && \
+   cd server && \
+   if [ "$BUILDPLATFORM" = "arm/v7" ] ; then dotnet restore -r linux-arm RdtClient.sln ; else dotnet restore RdtClient.sln ; fi && \
+   if [ "$BUILDPLATFORM" = "arm/v7" ] ; then dotnet publish -r linux-arm -c Release -o out ; else dotnet publish -c Release -o out ; fi
+
+# Stage 3 - Build runtime image
+FROM ghcr.io/linuxserver/baseimage-mono:LTS
+
+# set version label
+ARG BUILD_DATE
+ARG VERSION
+ARG RDTCLIENT_VERSION
+LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
+LABEL maintainer="ravensorb"
+
+# set environment variables
+ARG DEBIAN_FRONTEND="noninteractive"
+ENV XDG_CONFIG_HOME="/config/xdg"
+
+RUN mkdir /app || true && ln -s /config /data && mkdir -p /data/downloads /data/db || true && \
+    echo "**** Updating package information ****" && \ 
+    apt update -y -qq && \
+    apt install -y -qq wget p7zip-full && \
+    echo "**** Installing dotnet ****" && \
+    wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb  && \
+    dpkg -i packages-microsoft-prod.deb 2> /dev/null && \
+    rm packages-microsoft-prod.deb && \
+    apt update -y -qq && \
+    apt install -y -qq apt-transport-https dotnet-runtime-5.0 aspnetcore-runtime-5.0 && \
+    echo "**** Setting permissions ****" && \
+    chown -R abc:abc /data && \
+    echo "**** Cleaning image ****" && \
+    apt-get -y -qq -o Dpkg::Use-Pty=0 clean && apt-get -y -qq -o Dpkg::Use-Pty=0 purge && \
+    rm -rf \
+        /tmp/* \
+        /var/lib/apt/lists/* \
+        /var/tmp/* || true
+
+WORKDIR /app
+COPY --from=dotnet-build-env /appserver/server/out .
+COPY --from=node-build-env /appclient/client/out ./wwwroot
+
+RUN 7z a /data/downloads/RealDebridClient.zip .
+
+WORKDIR /data
+
+# add local files
+COPY root/ /
+
+# ports and volumes
+EXPOSE 6500
+VOLUME ["/config", "/data" ]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -29,6 +29,7 @@ FROM ghcr.io/linuxserver/baseimage-mono:LTS
 ARG BUILD_DATE
 ARG VERSION
 ARG RDTCLIENT_VERSION
+ARG DOTNET_VERSION=5.0
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="ravensorb"
 
@@ -45,7 +46,7 @@ RUN mkdir /app || true && ln -s /config /data && mkdir -p /data/downloads /data/
     dpkg -i packages-microsoft-prod.deb 2> /dev/null && \
     rm packages-microsoft-prod.deb && \
     apt update -y -qq && \
-    apt install -y -qq apt-transport-https dotnet-runtime-5.0 aspnetcore-runtime-5.0 && \
+    apt install -y -qq apt-transport-https dotnet-runtime-${DOTNET_VERSION} aspnetcore-runtime-${DOTNET_VERSION} && \
     echo "**** Setting permissions ****" && \
     chown -R abc:abc /data && \
     echo "**** Cleaning image ****" && \

--- a/docker-build-dev.bat
+++ b/docker-build-dev.bat
@@ -1,5 +1,5 @@
 docker stop rdtclientdev
 docker rm rdtclientdev
-docker build --tag rdtclientdev .
+docker build -f Dockerfile.build --tag rdtclientdev .
 docker run --cap-add=NET_ADMIN -d -v C:/Temp/RdtClient/:/data/downloads -v C:/Temp/RdtClient/:/data/db --log-driver json-file --log-opt max-size=10m -p 6500:6500 --name rdtclientdev rdtclientdev
 docker exec -it rdtclientdev /bin/bash

--- a/docker-compose-build-linux.yml
+++ b/docker-compose-build-linux.yml
@@ -1,0 +1,21 @@
+version: '3.3'
+
+services:
+    rdtclient:
+        container_name: rdtclient
+        image: rogerfar/rdtclient
+        build:
+          context: .
+          dockerfile: Dockerfile.build
+        volumes:
+            - ./data/downoads:/data/downloads
+            - ./data/db:/data/db
+        restart: always
+        logging:
+            driver: json-file
+            options:
+                max-size: 10m
+        ports:
+            - 6500:6500
+        cap_add: 
+            - NET_ADMIN

--- a/docker-compose-build-win.yml
+++ b/docker-compose-build-win.yml
@@ -1,0 +1,21 @@
+version: '3.3'
+
+services:
+    rdtclient:
+        container_name: rdtclient
+        image: rogerfar/rdtclient
+        build:
+          context: .
+          dockerfile: Dockerfile.build
+        volumes:
+            - 'C:/Downloads/:/data/downloads'
+            - 'C:/Docker/rdtclient/:/data/db'
+        restart: always
+        logging:
+            driver: json-file
+            options:
+                max-size: 10m
+        ports:
+            - 6500:6500
+        cap_add: 
+            - NET_ADMIN

--- a/docker-publish.bat
+++ b/docker-publish.bat
@@ -1,1 +1,1 @@
-docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag rogerfar/rdtclient .
+docker buildx build -f Dockerfile.build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag rogerfar/rdtclient .

--- a/dotnet-publish.ps1
+++ b/dotnet-publish.ps1
@@ -23,10 +23,13 @@ dotnet publish -c Release -o ..\out
 cd ..
 cd out
 
-Add-Type -Assembly System.IO.Compression.FileSystem
-$compressionLevel = [System.IO.Compression.CompressionLevel]::Optimal
 $location = Get-Location
-[System.IO.Compression.ZipFile]::CreateFromDirectory($location, "$location/../RealDebridClient.zip", $compressionLevel, $false)
+$compress = @{
+    Path=$location
+    CompressionLevel = "Fastest"
+    DestinationPath =  "$location/../RealDebridClient.zip"
+}
+Compress-Archive @compress
 
 cd ..
 

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,0 +1,13 @@
+#!/usr/bin/with-contenv bash
+
+# cleanup pid if it exists
+[[ -e /config/rtdclient.pid ]] && \
+	rm -rf /config/rtdclient.pid
+
+[[ -e /data/rtdclient.pid ]] && \
+	rm -rf /data/rtdclient.pid
+
+# permissions
+echo "Setting permissions"
+chown -R abc:abc \
+	/app /data /config

--- a/root/etc/services.d/rtdclient/run
+++ b/root/etc/services.d/rtdclient/run
@@ -1,0 +1,13 @@
+#!/usr/bin/with-contenv bash
+
+if [ -n "${UMASK_SET}" ] && [ -z "${UMASK}" ]; then
+  echo -e "You are using a legacy method of defining umask\nplease update your environment variable from UMASK_SET to UMASK\nto keep the functionality after July 2021"
+  umask ${UMASK_SET}
+fi
+
+echo "Changing to /app folder"
+cd /app || exit
+
+echo "Starting rtdclient"
+exec \
+  s6-setuidgid abc dotnet RdtClient.Web.dll


### PR DESCRIPTION
- Dockerfile.build will do a build based on the current code in the git repository
- Dockerfile will download the latest RealDebridClient.zip from git releases and install it (note you can specify a ARG to the build process to override and set the version to be installed)
- docker-compose-build-<OS>.yml is a docker-compose file that can be used to do a "docker-compose build" (os is either win or linux and just sets the volumes)
- Updated dotnet-publish to use Compress-Archive as it looks like MSFT fixed the "\\" issue (still needs to be tested, if it doesn't work your idea of switching to 7z makes a lot of sense)
- Added new files in /root folder that handle setting up the service using [s6-overlay](https://github.com/just-containers/s6-overlay)
- There is currently 1 additional RUN statement in Dockerfile.build that compresses the built solution and places it in the /data/downloads folder (I was using this to validate the zip file).  This can be removed, or it could be used for the build/publish process to git if you want
- There is a init script now that sets the permissions correctly on the /data and /app folder 
- The s6t-overlay is used to start the actual service under the correct user account now so that permissions work consistently 