### PR TITLE
Rootless Podman and CIFS Connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,14 @@ Notice: the progress and ETA reported in Sonarr's Activity tab will not be accur
 1. To stop: `docker stop rdtclient`
 1. To remove: `docker rm rdtclient`
 1. Or use `docker-build.bat`
+
+## Misc Install Notes
+
+### Rootless Podman, Linux Host, and CIFS Connections
+
+RDT Client read and write permission tests fail if the CIFS connection is not setup properly, despite permissions working inspection.  In the Web GUI, it will report access denied, and in the log file you will see exceptions like this ([dotnet issue](https://github.com/dotnet/runtime/issues/42790)): 
+```
+System.IO.IOException: Permission denied
+```
+The **nobrl** has to be specified in your CIFS connection - [man page](https://linux.die.net/man/8/mount.cifs). 
+Example: ```Options=_netdev,credentials=/etc/samba/credentials/600file,rw,uid=SUBUID,gid=SBUGID,nobrl,file_mode=0770,dir_mode=0770,noperm```


### PR DESCRIPTION
First, thanks for the awesome utility!

Some feedback on getting the client running on Arch using rootless Podman.  Works OOB with normal paths on the host and following the tips from LinuxServer.io, but some funny errors working with paths available through a CIFS mount.  

Still having some bugs I'm working out, but thought to get  a PR going if you thought these notes would be helpful to others.  These issues seem like an edge case; let me know if you want issues created for these.

## Issues
- [x] Access Denied Errors in Web GUI Tests ([dotnet runtime issue link](https://github.com/dotnet/runtime/issues/42790))
- [ ] Directory Does Not Exist To Extract To