### PR TITLE
fix: alldebrid progress percentage

### DIFF
--- a/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
@@ -55,7 +55,7 @@ namespace RdtClient.Service.Services.TorrentClients
                 OriginalBytes = torrent.Size,
                 Host = null,
                 Split = 0,
-                Progress = torrent.ProcessingPerc,
+                Progress = torrent.Downloaded * 100 / torrent.Size,
                 Status = torrent.Status,
                 StatusCode = torrent.StatusCode,
                 Added = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(torrent.UploadDate),


### PR DESCRIPTION
ProcessingPerc with alldebrid seems to be always 0. Added progress calculation based on downloaded and size. This seems to be how alldebrid UI handles it.