### PR TITLE
Filter torrents with the category query string:

### DIFF
--- a/server/RdtClient.Web/Controllers/QBittorrentController.cs
+++ b/server/RdtClient.Web/Controllers/QBittorrentController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -135,10 +136,20 @@ namespace RdtClient.Web.Controllers
         [Route("torrents/info")]
         [HttpGet]
         [HttpPost]
-        public async Task<ActionResult<IList<TorrentInfo>>> TorrentsInfo()
+        public async Task<ActionResult<IList<TorrentInfo>>> TorrentsInfo([FromQuery] QBTorrentsHashRequest request)
         {
-            var result = await _qBittorrent.TorrentInfo();
-            return Ok(result);
+            var results = await _qBittorrent.TorrentInfo();
+            IList<TorrentInfo> filteredResults = new List<TorrentInfo>();
+
+            if (request.Category == null) {
+                filteredResults = results;
+            } else if (request.Category == "") {
+                filteredResults = results.Where(m => m.Category == null).ToList();
+            } else {
+                filteredResults = results.Where(m => m.Category == request.Category).ToList();
+            }
+
+            return Ok(filteredResults);
         }
 
         [Authorize]
@@ -450,6 +461,7 @@ namespace RdtClient.Web.Controllers
     public class QBTorrentsHashRequest
     {
         public String Hash { get; set; }
+        public String Category { get; set; }
     }
 
     public class QBTorrentsDeleteRequest


### PR DESCRIPTION
- ### Problem

  When using multiple *arr instances (sonarr, radarr ...), the queue
  on each instance displays *all* torrents being processed by RDT.
  The normal behaviour is to display torrents that have the same
  category as the one set in the DownloadClient config on
  radarr/sonarr.

  ### Solution

  *arr uses the `/api/v2/torrents/info` QBittorrent endpoint which
  accepts a `category` query string.
  This is how the Qbittorent API behaves when that query string
  exists:

  ```text
  See https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-list

  Get torrents with the given category.
  empty string means "without category";
  no "category" parameter means "any category"
  ```

  See [here](https://github.com/Radarr/Radarr/blob/3125b038d5c2ca8c12f089059b7ca3303456aa9d/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs#L96) how radarr sets the categories when making the query.

  Thanks for your indulgence, first time writing dotnet :)