### PR TITLE
Updated download client dropdown when Symlink selected

### DIFF
--- a/client/src/app/models/setting.model.ts
+++ b/client/src/app/models/setting.model.ts
@@ -6,4 +6,5 @@ export class Setting {
   type: string;
   settings: Setting[];
   enumValues: { [key: string]: string };
+  originalEnumValues?: { [key: string]: string };
 }

--- a/client/src/app/settings/settings.component.html
+++ b/client/src/app/settings/settings.component.html
@@ -29,7 +29,7 @@
           {{ setting.displayName }}
         </label>
         <div class="control select is-fullwidth" *ngSwitchCase="'Enum'">
-          <select [(ngModel)]="setting.value">
+          <select [(ngModel)]="setting.value" (ngModelChange)="onDownloadClientChange(setting.value, setting.key)">
             <option [value]="kvp.key" *ngFor="let kvp of setting.enumValues | keyvalue">{{ kvp.value }}</option>
           </select>
         </div>


### PR DESCRIPTION
* Updated the settings page to hide the Remove Torrent From Provider options when the Download Client Symlink is selected

* Defaulted to Remove Torrent From Client when Symlink is selected apart from if No Action is already selected