### PR TITLE
Removed unwanted `VOLUME` as it has unintended side-effects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,6 @@ COPY --from=node-build-env /appclient/root/ /
 
 # ports and volumes
 EXPOSE 6500
-VOLUME [ "/data" ]
 
 # Check Status
 HEALTHCHECK --interval=30s --timeout=30s --start-period=30s --retries=3 CMD curl --fail http://localhost:6500 || exit 


### PR DESCRIPTION
The `VOLUME` definition has some unwanted side-effects, for example always creating a volume as mentioned here: https://github.com/rogerfar/rdt-client/issues/422