### PR TITLE
qBittorrent API improvements

### DIFF
--- a/client/src/app/torrent-status.pipe.ts
+++ b/client/src/app/torrent-status.pipe.ts
@@ -6,7 +6,7 @@ import { RealDebridStatus, Torrent } from './models/torrent.model';
   name: 'status',
 })
 export class TorrentStatusPipe implements PipeTransform {
-  constructor(private pipe: FileSizePipe) {}
+  constructor(private pipe: FileSizePipe) { }
 
   transform(torrent: Torrent): string {
     if (torrent.error) {
@@ -38,9 +38,8 @@ export class TorrentStatusPipe implements PipeTransform {
 
         speed = this.pipe.transform(allSpeeds, 'filesize');
 
-        return `Downloading file ${downloading.length + downloaded.length}/${
-          torrent.downloads.length
-        } (${progress.toFixed(2)}% - ${speed}/s)`;
+        return `Downloading file ${downloading.length + downloaded.length}/${torrent.downloads.length
+          } (${progress.toFixed(2)}% - ${speed}/s)`;
       }
 
       const unpacking = torrent.downloads.where((m) => m.unpackingStarted && !m.unpackingFinished && m.bytesDone > 0);
@@ -87,6 +86,9 @@ export class TorrentStatusPipe implements PipeTransform {
 
     switch (torrent.rdStatus) {
       case RealDebridStatus.Downloading:
+        if (torrent.rdSeeders < 1) {
+          return `Torrent stalled`
+        }
         const speed = this.pipe.transform(torrent.rdSpeed, 'filesize');
         return `Torrent downloading (${torrent.rdProgress}% - ${speed}/s)`;
       case RealDebridStatus.Processing:

--- a/client/src/app/torrent-table/torrent-table.component.html
+++ b/client/src/app/torrent-table/torrent-table.component.html
@@ -16,6 +16,7 @@
         <th>Name</th>
         <th>Category</th>
         <th>Priority</th>
+        <th>Seeders</th>
         <th>Files</th>
         <th>Downloads</th>
         <th>Size</th>
@@ -39,6 +40,9 @@
         </td>
         <td>
           {{ torrent.priority }}
+        </td>
+        <td>
+          {{ torrent.rdSeeders }}
         </td>
         <td>
           {{ torrent.files.length | number }}
@@ -74,7 +78,7 @@
     >
       Retry Selected
     </button>
-    
+
     <button
       class="button is-primary"
       (click)="changeSettingsModal()"


### PR DESCRIPTION
Hi, I noticed that the qBitorrent API was missing a few features:

- Reporting the `progress` of the debris torrent download
  - at the moment, the progress is always 0% until the torrent is downloaded in the debris
  - after this pr, the progress reports the torrent download from 0% to 50% and the host download from 50% to 100%
- Marking downloads properly `stalled`
  - after this pr, available seeders are reported properly
  - after this pr, when the Debris status is `downloading torrent` but there are no seeders, it marks the torrent status as `stalled`

In this PR, I also fix some floating point inconsistencies by switching from `Single` to `Decimal`
