### PR TITLE
download limit now takes in to consideration total active downloads

### DIFF
--- a/server/RdtClient.Service/Services/Downloaders/InternalDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/InternalDownloader.cs
@@ -26,7 +26,7 @@ public class InternalDownloader : IDownloader
 
         _uri = uri;
         _filePath = filePath;
-        
+
         _downloadConfiguration = new();
 
         SetSettings();
@@ -131,14 +131,14 @@ public class InternalDownloader : IDownloader
         {
             settingDownloadParallelCount = 1;
         }
-        
+
         var settingDownloadMaxSpeed = Settings.Get.DownloadClient.MaxSpeed;
 
         if (settingDownloadMaxSpeed <= 0)
         {
             settingDownloadMaxSpeed = 0;
         }
-
+        settingDownloadMaxSpeed = settingDownloadMaxSpeed / Math.Max(TorrentRunner.ActiveDownloadClients.Count, 1);
         settingDownloadMaxSpeed = settingDownloadMaxSpeed * 1024 * 1024;
 
         var settingDownloadTimeout = Settings.Get.DownloadClient.Timeout;


### PR DESCRIPTION
This PR tires to fix https://github.com/rogerfar/rdt-client/issues/579. 

With this fix the download speed limit will be consider between all active downloads.

Negative effect of this PR:
Because this https://github.com/rogerfar/Downloader.NET does not change the download speed for already started chunks, it would result in potentially slower download speed than expected.