### PR TITLE
Accept login via qbittorrent-api when AuthType is none

### DIFF
--- a/server/RdtClient.Web/Controllers/QBittorrentController.cs
+++ b/server/RdtClient.Web/Controllers/QBittorrentController.cs
@@ -21,6 +21,11 @@ public class QBittorrentController(ILogger<QBittorrentController> logger, QBitto
     {
         logger.LogDebug($"Auth login");
 
+        if (Settings.Get.General.AuthenticationType == AuthenticationType.None)
+        {
+            return Ok("Ok.");
+        }
+
         if (String.IsNullOrWhiteSpace(request.UserName) || String.IsNullOrEmpty(request.Password))
         {
             return Ok("Fails.");


### PR DESCRIPTION
When a login is requested e.g. by decluttarr via qbittorrent-api, but AuthenticationType is set to None, the API still requires correct userdata to be set.

I believe i have made changes to the correct code-location to always accept the login in that case.
Though i havent tested it or dug deeper into the code e.g. how the SID cookie gets set.. so this might not fully work like this.