### PR TITLE
[TorBox] Fix MethodNotAllowed, source parameter null, preventing download of files 

### DIFF
--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -291,8 +291,11 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
 
         var torrentId = await GetClient().Torrents.GetHashInfoAsync(torrent.Hash, skipCache: true);
 
-        var newFile = $"https://torbox.app/fakedl/{torrentId?.Id}/zip";
-        files.Add(newFile);
+        foreach (var file in torrent.Files!)
+        {
+            var newFile = $"https://torbox.app/fakedl/{torrentId?.Id}/{file.Id}";
+            files.Add(newFile);
+        }
 
         return files;
     }

--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -73,7 +73,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
             Progress = (Int64)((torrent.Progress) * 100.0),
             Status = torrent.DownloadState,
             Added = ChangeTimeZone(torrent.CreatedAt)!.Value,
-            Files = torrent.Files.Select(m => new TorrentClientFile
+            Files = (torrent.Files ?? []).Select(m => new TorrentClientFile
             {
                 Path = String.Join("/", m.Name.Split('/').Skip(1)),
                 Bytes = m.Size,
@@ -291,7 +291,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
 
         var torrentId = await GetClient().Torrents.GetHashInfoAsync(torrent.Hash, skipCache: true);
 
-        foreach (var file in torrent.Files!)
+        foreach (var file in torrent.Files)
         {
             var newFile = $"https://torbox.app/fakedl/{torrentId?.Id}/{file.Id}";
             files.Add(newFile);


### PR DESCRIPTION
This changes the download url to retrieve individual files, rather than zip. This will fix the MethodNotAllowed error preventing downloads from starting due to TorBox backend change. It also includes a fix for source parameter null error.

This should close #618.