### PR TITLE
Fix for TorBox incorrect filenames

### DIFF
--- a/client/src/app/setup/setup.component.html
+++ b/client/src/app/setup/setup.component.html
@@ -55,6 +55,7 @@
               <a href="https://www.premiumize.me/" target="_blank" rel="noopener"
                 >Use this link to sign up to Premiumize.</a
               >
+              <br />
               <a href="https://torbox.app/" target="_blank" rel="noopener"
                 >Use this link to sign up to TorBox.</a>
               <br />

--- a/server/RdtClient.Data/Data/DownloadData.cs
+++ b/server/RdtClient.Data/Data/DownloadData.cs
@@ -67,6 +67,23 @@ public class DownloadData(DataContext dataContext)
         await TorrentData.VoidCache();
     }
 
+    public async Task UpdateFileName(Guid downloadId, String fileName)
+    {
+        var dbDownload = await dataContext.Downloads
+                                           .FirstOrDefaultAsync(m => m.DownloadId == downloadId);
+
+        if (dbDownload == null)
+        {
+            return;
+        }
+
+        dbDownload.FileName = fileName;
+
+        await dataContext.SaveChangesAsync();
+
+        await TorrentData.VoidCache();
+    }
+
     public async Task UpdateDownloadStarted(Guid downloadId, DateTimeOffset? dateTime)
     {
         var dbDownload = await dataContext.Downloads

--- a/server/RdtClient.Data/Migrations/20241210071621_Downloads_Add_FileName.Designer.cs
+++ b/server/RdtClient.Data/Migrations/20241210071621_Downloads_Add_FileName.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using RdtClient.Data.Data;
 
@@ -10,9 +11,11 @@ using RdtClient.Data.Data;
 namespace RdtClient.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20241210071621_Downloads_Add_FileName")]
+    partial class Downloads_Add_FileName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/server/RdtClient.Data/Migrations/20241210071621_Downloads_Add_FileName.cs
+++ b/server/RdtClient.Data/Migrations/20241210071621_Downloads_Add_FileName.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RdtClient.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Downloads_Add_FileName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FileName",
+                table: "Downloads",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FileName",
+                table: "Downloads");
+        }
+    }
+}

--- a/server/RdtClient.Data/Models/Data/Download.cs
+++ b/server/RdtClient.Data/Models/Data/Download.cs
@@ -31,6 +31,8 @@ public class Download
 
     public String? RemoteId { get; set; }
 
+    public String? FileName { get; set; }
+
     [NotMapped]
     public Int64 BytesTotal { get; set; }
 

--- a/server/RdtClient.Data/Models/Internal/DbSettings.cs
+++ b/server/RdtClient.Data/Models/Internal/DbSettings.cs
@@ -152,11 +152,11 @@ At this point only 1 provider can be used at the time.")]
     [Description(@"You can find your API key here:
 <a href=""https://real-debrid.com/apitoken"" target=""_blank"" rel=""noopener"">https://real-debrid.com/apitoken</a>
 or
-<a href=""""https://alldebrid.com/apikeys/"""" target=""""_blank"""" rel=""""noopener"""">https://alldebrid.com/apikeys/</a>
+<a href=""https://alldebrid.com/apikeys/"" target=""_blank"" rel=""noopener"">https://alldebrid.com/apikeys/</a>
 or
 <a href=""https://www.premiumize.me/account/"" target=""_blank"" rel=""noopener"">https://www.premiumize.me/account/</a>
 or
-<a href=""""https://torbox.app/settings/"""" target=""""_blank"""" rel=""""noopener"""">https://torbox.app/settings/</a>")]
+<a href=""https://torbox.app/settings/"" target=""_blank"" rel=""noopener"">https://torbox.app/settings/</a>")]
     public String ApiKey { get; set; } = "";
 
     [DisplayName("Automatically import and process torrents added to provider")]

--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -5,11 +5,11 @@ namespace RdtClient.Service.Helpers;
 
 public static class DownloadHelper
 {
-    public static String? GetDownloadPath(String downloadPath, Torrent torrent, Download download, String? fileName = null)
+    public static String? GetDownloadPath(String downloadPath, Torrent torrent, Download download)
     {
         var fileUrl = download.Link;
 
-        if (String.IsNullOrWhiteSpace(fileUrl) || torrent.RdName == null || fileName == null)
+        if (String.IsNullOrWhiteSpace(fileUrl) || torrent.RdName == null)
         {
             return null;
         }
@@ -18,6 +18,8 @@ public static class DownloadHelper
 
         var uri = new Uri(fileUrl);
         var torrentPath = Path.Combine(downloadPath, directory);
+
+        var fileName = download.FileName;
 
         if (String.IsNullOrWhiteSpace(fileName))
         {
@@ -66,11 +68,14 @@ public static class DownloadHelper
         var uri = new Uri(fileUrl);
         var torrentPath = RemoveInvalidPathChars(torrent.RdName);
 
-        var fileName = uri.Segments.Last();
+        var fileName = download.FileName;
 
-        fileName = HttpUtility.UrlDecode(fileName);
+        if (String.IsNullOrWhiteSpace(fileName))
+        {
+            fileName = uri.Segments.Last();
 
-        fileName = FileHelper.RemoveInvalidFileNameChars(fileName);
+            fileName = HttpUtility.UrlDecode(fileName);
+        }
 
         var matchingTorrentFiles = torrent.Files.Where(m => m.Path.EndsWith(fileName)).Where(m => !String.IsNullOrWhiteSpace(m.Path)).ToList();
 

--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -5,11 +5,11 @@ namespace RdtClient.Service.Helpers;
 
 public static class DownloadHelper
 {
-    public static String? GetDownloadPath(String downloadPath, Torrent torrent, Download download)
+    public static String? GetDownloadPath(String downloadPath, Torrent torrent, Download download, String? fileName)
     {
         var fileUrl = download.Link;
 
-        if (String.IsNullOrWhiteSpace(fileUrl) || torrent.RdName == null)
+        if (String.IsNullOrWhiteSpace(fileUrl) || torrent.RdName == null || fileName == null)
         {
             return null;
         }
@@ -18,10 +18,6 @@ public static class DownloadHelper
 
         var uri = new Uri(fileUrl);
         var torrentPath = Path.Combine(downloadPath, directory);
-
-        var fileName = uri.Segments.Last();
-
-        fileName = HttpUtility.UrlDecode(fileName);
 
         fileName = FileHelper.RemoveInvalidFileNameChars(fileName);
 

--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -5,7 +5,7 @@ namespace RdtClient.Service.Helpers;
 
 public static class DownloadHelper
 {
-    public static String? GetDownloadPath(String downloadPath, Torrent torrent, Download download, String? fileName)
+    public static String? GetDownloadPath(String downloadPath, Torrent torrent, Download download, String? fileName = null)
     {
         var fileUrl = download.Link;
 
@@ -18,6 +18,13 @@ public static class DownloadHelper
 
         var uri = new Uri(fileUrl);
         var torrentPath = Path.Combine(downloadPath, directory);
+
+        if (String.IsNullOrWhiteSpace(fileName))
+        {
+            fileName = uri.Segments.Last();
+
+            fileName = HttpUtility.UrlDecode(fileName);
+        }
 
         fileName = FileHelper.RemoveInvalidFileNameChars(fileName);
 

--- a/server/RdtClient.Service/Services/Downloads.cs
+++ b/server/RdtClient.Service/Services/Downloads.cs
@@ -30,6 +30,11 @@ public class Downloads(DownloadData downloadData)
         await downloadData.UpdateUnrestrictedLink(downloadId, unrestrictedLink);
     }
 
+    public async Task UpdateFileName(Guid downloadId, String fileName)
+    {
+        await downloadData.UpdateFileName(downloadId, fileName);
+    }
+
     public async Task UpdateDownloadStarted(Guid downloadId, DateTimeOffset? dateTime)
     {
         await downloadData.UpdateDownloadStarted(downloadId, dateTime);

--- a/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using RdtClient.Data.Enums;
 using RdtClient.Data.Models.TorrentClient;
 using RdtClient.Service.Helpers;
+using System.Web;
 using File = AllDebridNET.File;
 using Torrent = RdtClient.Data.Models.Data.Torrent;
 
@@ -261,6 +262,17 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
         Log("", torrent);
 
         return links.Select(m => m.LinkUrl.ToString()).ToList();
+    }
+    public Task<String?> GetFileName(Data.Models.Data.Download download)
+    {
+        if (String.IsNullOrWhiteSpace(download.Link))
+        {
+            return Task.FromResult<String?>(null);
+        }
+
+        var uri = new Uri(download.Link);
+
+        return Task.FromResult<String?>(HttpUtility.UrlDecode(uri.Segments.Last()));
     }
 
     private async Task<TorrentClientTorrent> GetInfo(String torrentId)

--- a/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
@@ -263,14 +263,14 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
 
         return links.Select(m => m.LinkUrl.ToString()).ToList();
     }
-    public Task<String?> GetFileName(Data.Models.Data.Download download)
+    public Task<String?> GetFileName(String downloadUrl)
     {
-        if (String.IsNullOrWhiteSpace(download.Link))
+        if (String.IsNullOrWhiteSpace(downloadUrl))
         {
             return Task.FromResult<String?>(null);
         }
 
-        var uri = new Uri(download.Link);
+        var uri = new Uri(downloadUrl);
 
         return Task.FromResult<String?>(HttpUtility.UrlDecode(uri.Segments.Last()));
     }

--- a/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
@@ -263,16 +263,16 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
 
         return links.Select(m => m.LinkUrl.ToString()).ToList();
     }
-    public Task<String?> GetFileName(String downloadUrl)
+    public Task<String> GetFileName(String downloadUrl)
     {
         if (String.IsNullOrWhiteSpace(downloadUrl))
         {
-            return Task.FromResult<String?>(null);
+            return Task.FromResult("");
         }
 
         var uri = new Uri(downloadUrl);
 
-        return Task.FromResult<String?>(HttpUtility.UrlDecode(uri.Segments.Last()));
+        return Task.FromResult(HttpUtility.UrlDecode(uri.Segments.Last()));
     }
 
     private async Task<TorrentClientTorrent> GetInfo(String torrentId)

--- a/server/RdtClient.Service/Services/TorrentClients/ITorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/ITorrentClient.cs
@@ -15,5 +15,5 @@ public interface ITorrentClient
     Task<String> Unrestrict(String link);
     Task<Torrent> UpdateData(Torrent torrent, TorrentClientTorrent? torrentClientTorrent);
     Task<IList<String>?> GetDownloadLinks(Torrent torrent);
-    Task<String?> GetFileName(String downloadUrl);
+    Task<String> GetFileName(String downloadUrl);
 }

--- a/server/RdtClient.Service/Services/TorrentClients/ITorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/ITorrentClient.cs
@@ -15,4 +15,5 @@ public interface ITorrentClient
     Task<String> Unrestrict(String link);
     Task<Torrent> UpdateData(Torrent torrent, TorrentClientTorrent? torrentClientTorrent);
     Task<IList<String>?> GetDownloadLinks(Torrent torrent);
+    Task<String?> GetFileName(Download download);
 }

--- a/server/RdtClient.Service/Services/TorrentClients/ITorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/ITorrentClient.cs
@@ -15,5 +15,5 @@ public interface ITorrentClient
     Task<String> Unrestrict(String link);
     Task<Torrent> UpdateData(Torrent torrent, TorrentClientTorrent? torrentClientTorrent);
     Task<IList<String>?> GetDownloadLinks(Torrent torrent);
-    Task<String?> GetFileName(Download download);
+    Task<String?> GetFileName(String downloadUrl);
 }

--- a/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
@@ -4,6 +4,7 @@ using PremiumizeNET;
 using RdtClient.Data.Enums;
 using RdtClient.Data.Models.TorrentClient;
 using RdtClient.Service.Helpers;
+using System.Web;
 using Torrent = RdtClient.Data.Models.Data.Torrent;
 
 namespace RdtClient.Service.Services.TorrentClients;
@@ -239,6 +240,18 @@ public class PremiumizeTorrentClient(ILogger<PremiumizeTorrentClient> logger, IH
         }
 
         return downloadLinks;
+    }
+
+    public Task<String?> GetFileName(Data.Models.Data.Download download)
+    {
+        if (String.IsNullOrWhiteSpace(download.Link))
+        {
+            return Task.FromResult<String?>(null);
+        }
+
+        var uri = new Uri(download.Link);
+
+        return Task.FromResult<String?>(HttpUtility.UrlDecode(uri.Segments.Last()));
     }
 
     private async Task<TorrentClientTorrent> GetInfo(String id)

--- a/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
@@ -242,16 +242,16 @@ public class PremiumizeTorrentClient(ILogger<PremiumizeTorrentClient> logger, IH
         return downloadLinks;
     }
 
-    public Task<String?> GetFileName(String downloadUrl)
+    public Task<String> GetFileName(String downloadUrl)
     {
         if (String.IsNullOrWhiteSpace(downloadUrl))
         {
-            return Task.FromResult<String?>(null);
+            return Task.FromResult("");
         }
 
         var uri = new Uri(downloadUrl);
 
-        return Task.FromResult<String?>(HttpUtility.UrlDecode(uri.Segments.Last()));
+        return Task.FromResult(HttpUtility.UrlDecode(uri.Segments.Last()));
     }
 
     private async Task<TorrentClientTorrent> GetInfo(String id)

--- a/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
@@ -242,14 +242,14 @@ public class PremiumizeTorrentClient(ILogger<PremiumizeTorrentClient> logger, IH
         return downloadLinks;
     }
 
-    public Task<String?> GetFileName(Data.Models.Data.Download download)
+    public Task<String?> GetFileName(String downloadUrl)
     {
-        if (String.IsNullOrWhiteSpace(download.Link))
+        if (String.IsNullOrWhiteSpace(downloadUrl))
         {
             return Task.FromResult<String?>(null);
         }
 
-        var uri = new Uri(download.Link);
+        var uri = new Uri(downloadUrl);
 
         return Task.FromResult<String?>(HttpUtility.UrlDecode(uri.Segments.Last()));
     }

--- a/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
@@ -396,16 +396,16 @@ public class RealDebridTorrentClient(ILogger<RealDebridTorrentClient> logger, IH
         return null;
     }
 
-    public Task<String?> GetFileName(String downloadUrl)
+    public Task<String> GetFileName(String downloadUrl)
     {
         if (String.IsNullOrWhiteSpace(downloadUrl))
         {
-            return Task.FromResult<String?>(null);
+            return Task.FromResult("");
         }
 
         var uri = new Uri(downloadUrl);
 
-        return Task.FromResult<String?>(HttpUtility.UrlDecode(uri.Segments.Last()));
+        return Task.FromResult(HttpUtility.UrlDecode(uri.Segments.Last()));
     }
 
     private DateTimeOffset? ChangeTimeZone(DateTimeOffset? dateTimeOffset)

--- a/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
@@ -396,14 +396,14 @@ public class RealDebridTorrentClient(ILogger<RealDebridTorrentClient> logger, IH
         return null;
     }
 
-    public Task<String?> GetFileName(Data.Models.Data.Download download)
+    public Task<String?> GetFileName(String downloadUrl)
     {
-        if (String.IsNullOrWhiteSpace(download.Link))
+        if (String.IsNullOrWhiteSpace(downloadUrl))
         {
             return Task.FromResult<String?>(null);
         }
 
-        var uri = new Uri(download.Link);
+        var uri = new Uri(downloadUrl);
 
         return Task.FromResult<String?>(HttpUtility.UrlDecode(uri.Segments.Last()));
     }

--- a/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System.Web;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using RDNET;
@@ -393,6 +394,18 @@ public class RealDebridTorrentClient(ILogger<RealDebridTorrentClient> logger, IH
         Log($"Did not find any suiteable download links", torrent);
             
         return null;
+    }
+
+    public Task<String?> GetFileName(Data.Models.Data.Download download)
+    {
+        if (String.IsNullOrWhiteSpace(download.Link))
+        {
+            return Task.FromResult<String?>(null);
+        }
+
+        var uri = new Uri(download.Link);
+
+        return Task.FromResult<String?>(HttpUtility.UrlDecode(uri.Segments.Last()));
     }
 
     private DateTimeOffset? ChangeTimeZone(DateTimeOffset? dateTimeOffset)

--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -161,7 +161,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
     {
         var availability = await GetClient().Torrents.GetAvailabilityAsync(hash, listFiles: true);
 
-        if (availability.Data != null)
+        if (availability.Data != null || availability.Data?.Count < 0)
         {
             return (availability.Data[0]?.Files ?? []).Select(file => new TorrentClientAvailableFile
                                                       {
@@ -302,18 +302,18 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
         return files;
     }
 
-    public async Task<String?> GetFileName(Data.Models.Data.Download download)
+    public async Task<String?> GetFileName(String downloadUrl)
     {
-        if (String.IsNullOrWhiteSpace(download.Link))
+        if (String.IsNullOrWhiteSpace(downloadUrl))
         {
             return null;
         }
 
-        var uri = new Uri(download.Link);
+        var uri = new Uri(downloadUrl);
 
-        using (HttpClient client = new HttpClient())
+        using (HttpClient client = new())
         {
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Head, uri);
+            HttpRequestMessage request = new(HttpMethod.Head, uri);
             HttpResponseMessage response = await client.SendAsync(request);
             if (response.Content.Headers.ContentDisposition != null)
             {

--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -258,6 +258,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
                     "checking" => TorrentStatus.Processing,
                     "checkingResumeData" => TorrentStatus.Processing,
                     "paused" => TorrentStatus.Downloading,
+                    "stalledDL" => TorrentStatus.Downloading,
                     "downloading" => TorrentStatus.Downloading,
                     "completed" => TorrentStatus.Downloading,
                     "uploading" => TorrentStatus.Downloading,

--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -302,11 +302,11 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
         return files;
     }
 
-    public async Task<String?> GetFileName(String downloadUrl)
+    public async Task<String> GetFileName(String downloadUrl)
     {
         if (String.IsNullOrWhiteSpace(downloadUrl))
         {
-            return null;
+            return "";
         }
 
         var uri = new Uri(downloadUrl);

--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -349,6 +349,9 @@ public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Dow
 
                             var downloadLink = await torrents.UnrestrictLink(download.DownloadId);
                             download.Link = downloadLink;
+
+                            var fileName = await torrents.RetrieveFileName(download.DownloadId);
+                            download.FileName = fileName;
                         }
                     }
                     catch (Exception ex)

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -374,7 +374,7 @@ public class Torrents(
     {
         var download = await downloads.GetById(downloadId) ?? throw new($"Download with ID {downloadId} not found");
 
-        Log($"Unrestricting link", download, download.Torrent);
+        Log($"Retrieving filename for", download, download.Torrent);
 
         var fileName = await TorrentClient.GetFileName(download.Link!);
 

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -370,6 +370,19 @@ public class Torrents(
         return unrestrictedLink;
     }
 
+    public async Task<String> RetrieveFileName(Guid downloadId)
+    {
+        var download = await downloads.GetById(downloadId) ?? throw new($"Download with ID {downloadId} not found");
+
+        Log($"Unrestricting link", download, download.Torrent);
+
+        var fileName = await TorrentClient.GetFileName(download.Link!);
+
+        await downloads.UpdateFileName(downloadId, fileName);
+
+        return fileName;
+    }
+
     public async Task<Profile> GetProfile()
     {
         var user = await TorrentClient.GetUser();
@@ -547,9 +560,7 @@ public class Torrents(
 
         var downloadPath = DownloadPath(download.Torrent!);
 
-        var fileName = await TorrentClient.GetFileName(download);
-            
-        var filePath = DownloadHelper.GetDownloadPath(downloadPath, download.Torrent!, download, fileName);
+        var filePath = DownloadHelper.GetDownloadPath(downloadPath, download.Torrent!, download);
 
         if (filePath != null)
         {

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -546,8 +546,10 @@ public class Torrents(
         }
 
         var downloadPath = DownloadPath(download.Torrent!);
+
+        var fileName = await TorrentClient.GetFileName(download);
             
-        var filePath = DownloadHelper.GetDownloadPath(downloadPath, download.Torrent!, download);
+        var filePath = DownloadHelper.GetDownloadPath(downloadPath, download.Torrent!, download, fileName);
 
         if (filePath != null)
         {


### PR DESCRIPTION
This PR fixes the issue in #616 where filenames are being named to the download uuid. It does this by adding a new function to the TorrentClients to handle filenames from a downloadurl, which is saved in the db under each download item.

This has been tested with Internal, Aria2, and Bezzad. I tried testing with Symlink but the TorBox webdav was timing out for me. 

This will close #616.