### PR TITLE
[TB] Fix source parameter null log spam #618

### DIFF
--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -74,7 +74,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
             Progress = (Int64)(torrent.Progress * 100.0),
             Status = torrent.DownloadState,
             Added = ChangeTimeZone(torrent.CreatedAt)!.Value,
-            Files = (torrent.Files).Select(m => new TorrentClientFile
+            Files = (torrent.Files ?? []).Select(m => new TorrentClientFile
             {
                 Path = String.Join("/", m.Name.Split('/').Skip(1)),
                 Bytes = m.Size,


### PR DESCRIPTION
This is a fix for source parameter null log spam.

This is caused when a torrent is taking a while during metaDL, or when a torrent errors out, the value of files can/will be null, and if the `?? []` is removed it causes the log spam from #618.