### PR TITLE
fix(AllDebrid): Implement regex filters & preserve folder structure

### DIFF
--- a/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
@@ -1,4 +1,5 @@
-﻿using AllDebridNET;
+﻿using System.Text.RegularExpressions;
+using AllDebridNET;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using RdtClient.Data.Enums;
@@ -6,6 +7,7 @@ using RdtClient.Data.Models.TorrentClient;
 using RdtClient.Service.Helpers;
 using System.Web;
 using File = AllDebridNET.File;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 using Torrent = RdtClient.Data.Models.Data.Torrent;
 
 namespace RdtClient.Service.Services.TorrentClients;
@@ -62,7 +64,7 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
             Added = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(torrent.UploadDate),
             Files = torrent.Links.Select((m, i) => new TorrentClientFile
             {
-                Path = m.Filename,
+                Path = GetFiles(m.Files),
                 Bytes = m.Size,
                 Id = i,
                 Selected = true,
@@ -242,6 +244,53 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
 
             Log($"Found {links.Count} files that match the minimum file size criterea", torrent);
         }
+        
+        if (!String.IsNullOrWhiteSpace(torrent.IncludeRegex))
+        {
+            Log($"Using regular expression {torrent.IncludeRegex} to include only files matching this regex", torrent);
+        
+            var newLinks = new List<Link>();
+            foreach (var link in links)
+            {
+                var path = GetFiles(link.Files);
+                if (Regex.IsMatch(path, torrent.IncludeRegex))
+                {
+                    Log($"* Including {path}", torrent);
+                    newLinks.Add(link);
+                }
+                else
+                {
+                    Log($"* Excluding {path}", torrent);
+                }
+            }
+        
+            links = newLinks;
+        
+            Log($"Found {newLinks.Count} files that match the regex", torrent);
+        } 
+        else if (!String.IsNullOrWhiteSpace(torrent.ExcludeRegex))
+        {
+            Log($"Using regular expression {torrent.IncludeRegex} to ignore files matching this regex", torrent);
+        
+            var newLinks = new List<Link>();
+            foreach (var link in links)
+            {
+                var path = GetFiles(link.Files);
+                if (!Regex.IsMatch(path, torrent.ExcludeRegex))
+                {
+                    Log($"* Including {path}", torrent);
+                    newLinks.Add(link);
+                }
+                else
+                {
+                    Log($"* Excluding {path}", torrent);
+                }
+            }
+        
+            links = newLinks;
+        
+            Log($"Found {newLinks.Count} files that match the regex", torrent);
+        }
 
         if (links.Count == 0)
         {
@@ -250,15 +299,16 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
             links = magnet.Links;
         }
 
-        Log($"Selecting links:");
-
-        foreach (var link in links)
+        if (logger.IsEnabled(LogLevel.Debug))
         {
-            var fileList = GetFiles(link.Files, "");
+            Log($"Selecting links:");
 
-            Log($"{link.Filename} ({link.Size}b) {link.LinkUrl}, contains files:{Environment.NewLine}{String.Join(Environment.NewLine, fileList)}");
+            foreach (var link in links)
+            {
+                Log($"{GetFiles(link.Files)} ({link.Size}b) {link.LinkUrl}");
+            }
         }
-
+        
         Log("", torrent);
 
         return links.Select(m => m.LinkUrl.ToString()).ToList();
@@ -282,7 +332,7 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
         return Map(result);
     }
 
-    private static List<String> GetFiles(IList<File> files, String parent)
+    private static String GetFiles(IList<File> files)
     {
         var result = new List<String>();
 
@@ -290,19 +340,24 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
         {
             if (!String.IsNullOrWhiteSpace(file.N))
             {
-                result.Add($"{parent}/{file.N}");
+                result.Add(file.N);
             }
 
             if (file.E != null && file.E.Value.PurpleEArray != null && file.E.Value.PurpleEArray.Count > 0)
             {
-                result.AddRange(GetFiles(file.E.Value.PurpleEArray, file.N));
+                if (file.E.Value.PurpleEArray.Count != 1)
+                {
+                    throw new("Unexpected number of nested files");
+                }
+                
+                result.AddRange(GetFiles(file.E.Value.PurpleEArray));
             }
         }
 
-        return result;
+        return String.Join("/", result);
     }
 
-    private static List<String> GetFiles(IList<FileE1> files, String parent)
+    private static List<String> GetFiles(IList<FileE1> files)
     {
         var result = new List<String>();
 
@@ -310,19 +365,19 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
         {
             if (!String.IsNullOrWhiteSpace(file.N))
             {
-                result.Add($"{parent}/{file.N}");
+                result.Add(file.N);
             }
 
             if (file.E != null && file.E.Count > 0)
             {
-                result.AddRange(GetFiles(file.E, file.N));
+                result.AddRange(GetFiles(file.E));
             }
         }
 
         return result;
     }
 
-    private static List<String> GetFiles(IList<FileE2> files, String parent)
+    private static List<String> GetFiles(IList<FileE2> files)
     {
         var result = new List<String>();
 
@@ -330,7 +385,7 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
         {
             if (!String.IsNullOrWhiteSpace(file.N))
             {
-                result.Add($"{parent}/{file.N}");
+                result.Add(file.N);
             }
         }
 


### PR DESCRIPTION
Fixes #594 (specifically https://github.com/rogerfar/rdt-client/issues/594#issuecomment-2494975478).
Fixes #399 (again, see https://github.com/rogerfar/rdt-client/issues/399#issuecomment-2569935647).
Possibly fixes #648 (if I understood the issue correctly?).

This PR fixes 2 issues (both related to AllDebrid):
- Folder structure not being preserved.
- Include/exclude filters not working.

Both are fixed in the same PR because they depend on each other.
The first issue is fixed by reconstructing the path and using that as the file path, instead of only the filename.

The filters weren't implemented because a single link could have multiple files, as specified by this comment from 2021: https://github.com/rogerfar/rdt-client/issues/44#issuecomment-955615719
I've checked with multiple torrents, and could not find any case where a single link was used for multiple files, so I'm going to safely assume this is no longer the case (and my tests agreed with this conclusion).

I've tested this PR with the following torrent (`<nyaa dot si>/view/1350495`) and everything worked as it should. The folder structure of the original torrent was preserved (episodes properly placed in their season folders), and it only downloaded MKV files and excluded all of the fanart/cover art/etc (with the following include regex: `.mkv`).

---

One thing I noticed while trying to set up the project is that, no matter what I did, this line just wouldn't work:
https://github.com/rogerfar/rdt-client/blob/8518cc1e103ec390146168957d617e8030d754c0/client/src/app/app.module.ts#L8
After much trial and error, I figured out I had to replace it with `import 'curray';` and remove the `curray();` call below.
Maybe this is just an issue on my end, but I thought I'd mention it. Not sure why it happens though.