### PR TITLE
fix: Fix invalid download path with single-file torrents

### DIFF
--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -43,6 +43,14 @@ public static class DownloadHelper
                 subPath = subPath.Trim('/').Trim('\\');
 
                 torrentPath = Path.Combine(torrentPath, subPath);
+            } else if (torrent.Files.Count == 1)
+            {
+                if (directory != fileName)
+                {
+                    throw new($"Torrent path {torrentPath} does not match file name {fileName}. This is a requirement for single file torrents.");
+                }
+            
+                return torrentPath;
             }
         }
 
@@ -90,6 +98,14 @@ public static class DownloadHelper
                 subPath = subPath.Trim('/').Trim('\\');
 
                 torrentPath = Path.Combine(torrentPath, subPath);
+            } else if (torrent.Files.Count == 1)
+            {
+                if (torrentPath != fileName)
+                {
+                    throw new($"Torrent path {torrentPath} does not match file name {fileName}. This is a requirement for single file torrents.");
+                }
+            
+                return torrentPath;
             }
         }
 


### PR DESCRIPTION
Fixes #648.

You can't have multiple files at the root of a torrent. It's either a single file or a directory containing multiple files.
AllDebrid goes along with this and doesn't place torrents in a directory if it only contains a single file. RDT didn't handle this case.

This was fine, except for the people using AllDebrid with the rclone/symlink downloader. People using the other downloaders would've noticed that their files got placed into a directory with the same name as the file it contains, which shouldn't happen.

I've tested this with AllDebrid and the internal downloader using a single-file torrent and a multi-file torrent,
`<nyaa dot si>/view/1806288` and `<nyaa dot si>/view/1350495` respectively. The single-file torrent was placed in `/data/downloads/FILE.mkv`, and the files and directories of the multi-file torrent were placed in `/data/downloads/TORRENTNAME/`, which is what I expected to see.

@Cucumberrbob @bob1321 Can you please let me know if this has fixed your issue? I believe it should've.
@rogerfar, or anyone with access to RealDebrid, can you check if this still works as expected for you?
If not, we may have to add a check for AllDebrid and only do this when AllDebrid is used to download the torrent.