### PR TITLE
Add Synology Download Station Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ By default the application runs in the root of your hosted address (i.e. https:/
 - (optional) Resharper
 
 1. Open the client folder project in VS Code and run `npm install`.
-1. To debug run `ng serve`, to build run `ng build --prod`.
+1. To debug run `ng serve`, to build run `ng build -c production`.
 1. Open the Visual Studio 2019 project `RdtClient.sln` and `Publish` the `RdtClient.Web` to the given `PublishFolder` target.
 1. When debugging, make sure to run `RdtClient.Web.dll` and not `IISExpress`.
 1. The result is found in `Publish`.

--- a/client/src/app/add-new-torrent/add-new-torrent.component.html
+++ b/client/src/app/add-new-torrent/add-new-torrent.component.html
@@ -50,6 +50,7 @@
           <option [ngValue]="1">Bezzad</option>
           <option [ngValue]="2">Aria2c</option>
           <option [ngValue]="3">Symlink Downloader</option>
+          <option [ngValue]="4">Synology DownloadStation</option>
         </select>
       </div>
       <p class="help">

--- a/client/src/app/torrent-table/torrent-table.component.html
+++ b/client/src/app/torrent-table/torrent-table.component.html
@@ -191,6 +191,7 @@
             <option [ngValue]="1">Bezzad</option>
             <option [ngValue]="2">Aria2c</option>
             <option [ngValue]="3">Symlink Downloader</option>
+            <option [ngValue]="4">Synology DownloadStation</option>
           </select>
         </div>
         <p class="help">

--- a/client/src/app/torrent/torrent.component.html
+++ b/client/src/app/torrent/torrent.component.html
@@ -58,6 +58,7 @@
           <ng-container *ngSwitchCase="1">Bezadd</ng-container>
           <ng-container *ngSwitchCase="2">Aria2c</ng-container>
           <ng-container *ngSwitchCase="3">Symlink Downloader</ng-container>
+          <ng-component *ngSwitchCase="4">Synology DownloadStation</ng-component>
         </ng-container>
       </div>
       <div class="field">
@@ -498,6 +499,7 @@
             <option [ngValue]="1">Bezzad</option>
             <option [ngValue]="2">Aria2c</option>
             <option [ngValue]="3">Symlink Downloader</option>
+            <option [ngValue]="4">Synology DownloadStation</option>
           </select>
         </div>
         <p class="help">

--- a/server/RdtClient.Data/Enums/DownloadClient.cs
+++ b/server/RdtClient.Data/Enums/DownloadClient.cs
@@ -15,4 +15,7 @@ public enum DownloadClient
 
     [Description("Symlink Downloader")]
     Symlink,
+
+    [Description("Synology DownloadStation")]
+    DownloadStation,
 }

--- a/server/RdtClient.Data/Models/Internal/DbSettings.cs
+++ b/server/RdtClient.Data/Models/Internal/DbSettings.cs
@@ -1,5 +1,5 @@
-﻿using System.ComponentModel;
-using RdtClient.Data.Enums;
+﻿using RdtClient.Data.Enums;
+using System.ComponentModel;
 
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
 
@@ -123,7 +123,7 @@ http://127.0.0.1:6800/jsonrpc.")]
     [DisplayName("Aria2c Secret (only used for the Aria2c Downloader)")]
     [Description("The secret of your Aria2c instance. Optional.")]
     public String Aria2cSecret { get; set; } = "mysecret123";
-    
+
     [DisplayName("Aria2c Download Path")]
     [Description("The root path to download the file to on the Aria2c host, if empty use the Download path setting.")]
     public String? Aria2cDownloadPath { get; set; } = null;
@@ -131,6 +131,21 @@ http://127.0.0.1:6800/jsonrpc.")]
     [DisplayName("Rclone mount path (only used for the Symlink Downloader)")]
     [Description("Path where Rclone is mounted. Required for Symlink Downloader. Suffix this path with a * to search subdirectories too.")]
     public String RcloneMountPath { get; set; } = "/mnt/rd/";
+
+    [DisplayName("Synology DownloadStation URL")]
+    [Description("The URL to the Synology DownloadStation. A common URL is http://127.0.0.1:5000")]
+    public String DownloadStationUrl { get; set; } = "http://127.0.0.1:5000";
+
+    [DisplayName("Synology DownloadStation Username")]
+    [Description("The username to use when connecting to the Synology DownloadStation.")]
+    public String? DownloadStationUsername { get; set; } = null;
+    [DisplayName("Synology DownloadStation Password")]
+    [Description("The password to use when connecting to the Synology DownloadStation.")]
+    public String? DownloadStationPassword { get; set; } = null;
+
+    [DisplayName("Synology Download Station Download Path")]
+    [Description("The root path to doawnload the file on the Synology DownloadStation host, if empty use the default DownloadStation path but won't create catagory folders.")]
+    public String? DownloadStationDownloadPath { get; set; } = null;
 
     [DisplayName("Log level")]
     [Description("Only set when trying to debug a download client, can generate a lot of logs.")]

--- a/server/RdtClient.Data/Models/Internal/DbSettings.cs
+++ b/server/RdtClient.Data/Models/Internal/DbSettings.cs
@@ -144,7 +144,7 @@ http://127.0.0.1:6800/jsonrpc.")]
     public String? DownloadStationPassword { get; set; } = null;
 
     [DisplayName("Synology Download Station Download Path")]
-    [Description("The root path to doawnload the file on the Synology DownloadStation host, if empty use the default DownloadStation path but won't create catagory folders.")]
+    [Description("The root path to doawnload the file on the Synology DownloadStation host, if empty use the default DownloadStation path.")]
     public String? DownloadStationDownloadPath { get; set; } = null;
 
     [DisplayName("Log level")]

--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -1,5 +1,5 @@
-﻿using System.Web;
-using RdtClient.Data.Models.Data;
+﻿using RdtClient.Data.Models.Data;
+using System.Web;
 
 namespace RdtClient.Service.Helpers;
 
@@ -15,6 +15,9 @@ public static class DownloadHelper
         }
 
         var directory = RemoveInvalidPathChars(torrent.RdName);
+
+        // RealDebrid sometimes change TorrentName when it's a single file torrent adding the extension of the single file
+        directory = Path.ChangeExtension(directory, null);
 
         var uri = new Uri(fileUrl);
         var torrentPath = Path.Combine(downloadPath, directory);

--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -16,9 +16,6 @@ public static class DownloadHelper
 
         var directory = RemoveInvalidPathChars(torrent.RdName);
 
-        // RealDebrid sometimes change TorrentName when it's a single file torrent adding the extension of the single file
-        directory = Path.ChangeExtension(directory, null);
-
         var uri = new Uri(fileUrl);
         var torrentPath = Path.Combine(downloadPath, directory);
 

--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -22,12 +22,12 @@
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="SharpCompress" Version="0.38.0" />
+    <PackageReference Include="Synology.Api.Client" Version="0.3.87" />
     <PackageReference Include="TorBox.NET" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\RdtClient.Data\RdtClient.Data.csproj" />
-    <ProjectReference Include="..\..\..\Synology.Api.Client\src\Synology.Api.Client\Synology.Api.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Serilog" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="SharpCompress" Version="0.38.0" />
+    <PackageReference Include="Synology.Api.Client" Version="0.2.66" />
   </ItemGroup>
 
   <ItemGroup>

--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -22,11 +22,11 @@
     <PackageReference Include="Serilog" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="SharpCompress" Version="0.38.0" />
-    <PackageReference Include="Synology.Api.Client" Version="0.2.68" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\RdtClient.Data\RdtClient.Data.csproj" />
+    <ProjectReference Include="..\..\..\Synology.Api.Client\src\Synology.Api.Client\Synology.Api.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Serilog" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="SharpCompress" Version="0.38.0" />
-    <PackageReference Include="Synology.Api.Client" Version="0.2.66" />
+    <PackageReference Include="Synology.Api.Client" Version="0.2.68" />
   </ItemGroup>
 
   <ItemGroup>

--- a/server/RdtClient.Service/Services/DownloadClient.cs
+++ b/server/RdtClient.Service/Services/DownloadClient.cs
@@ -52,6 +52,7 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
                 Data.Enums.DownloadClient.Bezzad => new BezzadDownloader(download.Link, filePath),
                 Data.Enums.DownloadClient.Aria2c => new Aria2cDownloader(download.RemoteId, download.Link, filePath, downloadPath, category),
                 Data.Enums.DownloadClient.Symlink => new SymlinkDownloader(download.Link, filePath, downloadPath),
+                Data.Enums.DownloadClient.DownloadStation => await DownloadStationDownloader.Init(download.RemoteId, download.Link, filePath, downloadPath, category),
                 _ => throw new($"Unknown download client {Type}")
             };
 

--- a/server/RdtClient.Service/Services/Downloaders/DownloadStationDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/DownloadStationDownloader.cs
@@ -1,0 +1,189 @@
+﻿
+using Serilog;
+using Synology.Api.Client;
+using Synology.Api.Client.Apis.DownloadStation.Task.Models;
+
+namespace RdtClient.Service.Services.Downloaders;
+
+public class DownloadStationDownloader : IDownloader
+{
+    public event EventHandler<DownloadCompleteEventArgs>? DownloadComplete;
+    public event EventHandler<DownloadProgressEventArgs>? DownloadProgress;
+
+    private const Int32 RetryCount = 5;
+
+    private readonly SynologyClient _synologyClient;
+
+    private readonly ILogger _logger;
+    private readonly String _uri;
+    private readonly String _filePath;
+    private readonly String? _remotePath;
+
+    private String? _gid;
+    private DownloadStationDownloader(String? gid, String uri, String filePath, String downloadPath, String? category)
+    {
+        _logger = Log.ForContext<DownloadStationDownloader>();
+        _logger.Debug($"Instantiated new DownloadStation Downloader for URI {uri} to filePath {filePath} and downloadPath {downloadPath} and GID {gid}");
+
+        _gid = gid;
+        _uri = uri;
+        _filePath = filePath;
+
+        _remotePath = !String.IsNullOrWhiteSpace(Settings.Get.DownloadClient.DownloadStationDownloadPath)
+            ? String.IsNullOrWhiteSpace(category)
+                ? Path.Combine(ToCurrentPath(Settings.Get.DownloadClient.DownloadStationDownloadPath))
+                : Path.Combine(ToCurrentPath(Settings.Get.DownloadClient.DownloadStationDownloadPath), category)
+            : null;
+
+        _synologyClient = new SynologyClient(Settings.Get.DownloadClient.DownloadStationUrl);
+    }
+
+    public static async Task<DownloadStationDownloader> Init(String? gid, String uri, String filePath, String downloadPath, String? category)
+    {
+        var result = new DownloadStationDownloader(gid, uri, filePath, downloadPath, category);
+        if (Settings.Get.DownloadClient.DownloadStationUsername != null && Settings.Get.DownloadClient.DownloadStationPassword != null)
+            await result._synologyClient.LoginAsync(Settings.Get.DownloadClient.DownloadStationUsername, Settings.Get.DownloadClient.DownloadStationPassword);
+
+        return result;
+    }
+
+    public async Task Cancel()
+    {
+        if (_gid != null)
+        {
+            _logger.Debug($"Remove download {_uri} {_gid} from Synology DownloadStation");
+
+            await _synologyClient.DownloadStationApi().TaskEndpoint().DeleteAsync(new DownloadStationTaskDeleteRequest
+            {
+                Ids = new List<string> { _gid },
+                ForceComplete = false
+            });
+        }
+    }
+
+    public async Task<string> Download()
+    {
+        var path = _remotePath != null ? ToUnixPath(_remotePath) : null;
+        _logger.Debug($"Starting download of {_uri}, writing to path: {path}");
+
+        if (_gid != null)
+        {
+            if (GetTask() != null)
+            {
+                throw new($"The download link {_uri} has already been added to DownloadStation");
+            }
+        }
+
+
+        var retryCount = 0;
+        while (retryCount < 5)
+        {
+            _gid = await GetGidFromUri();
+            if (_gid != null)
+            {
+                _logger.Debug($"Download with ID {_gid} found in DownloadStation");
+                return _gid;
+            }
+
+            var createResult = await _synologyClient
+                .DownloadStationApi()
+                .TaskEndpoint()
+                .CreateAsync(new DownloadStationTaskCreateRequest(_uri, path));
+
+            _logger.Debug($"Added download to DownloadStation, received ID {_gid}");
+
+            if (createResult.Success)
+            {
+                _gid = await GetGidFromUri();
+                if (_gid != null)
+                {
+                    _logger.Debug($"Download with ID {_gid} found in DownloadStation");
+                    return _gid;
+                }
+                else
+                {
+                    retryCount++;
+                    _logger.Debug($"Task not found in DownloadStation after creat Sucess. Retrying {retryCount}/{RetryCount}");
+                    await Task.Delay(retryCount * 1000);
+                }
+            }
+            else
+            {
+                retryCount++;
+                _logger.Debug($"Error starting download: {createResult.Error.Code}. Retrying {retryCount}/{RetryCount}");
+                await Task.Delay(retryCount * 1000);
+            }
+        }
+
+        throw new Exception($"Unable to download file");
+    }
+
+    private async Task<String?> GetGidFromUri()
+    {
+        var tasks = await _synologyClient.DownloadStationApi().TaskEndpoint().ListAsync();
+        return tasks.Tasks.FirstOrDefault(t => t.Additional?.Detail?.Uri == _uri)?.Id;
+    }
+
+    public async Task Pause()
+    {
+        _logger.Debug($"Pausing download {_uri} {_gid}");
+        if (_gid != null)
+            await _synologyClient.DownloadStationApi().TaskEndpoint().PauseAsync(_gid);
+    }
+
+    public async Task Resume()
+    {
+        _logger.Debug($"Resuming download {_uri} {_gid}");
+        if (_gid != null)
+            await _synologyClient.DownloadStationApi().TaskEndpoint().ResumeAsync(_gid);
+    }
+
+    public async Task Update()
+    {
+        if (_gid == null)
+            return;
+
+        var task = await GetTask();
+
+        if (task == null)
+        {
+            DownloadComplete?.Invoke(this, new() { Error = "Task not found" });
+            return;
+        }
+
+        if (task.Status == "finished")
+        {
+            DownloadComplete?.Invoke(this, new() { Error = null });
+            return;
+        }
+
+        DownloadProgress?.Invoke(this, new()
+        {
+            BytesDone = task.Additional.Transfer.SizeDownloaded,
+            BytesTotal = task.Size,
+            Speed = task.Additional.Transfer.SpeedDownload
+        });
+    }
+
+    private static string ToUnixPath(string path)
+    {
+        return path.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private static string ToCurrentPath(string path)
+    {
+        return path.Replace('/', Path.DirectorySeparatorChar);
+    }
+
+    private async Task<DownloadStationTask?> GetTask()
+    {
+        try
+        {
+            return await _synologyClient.DownloadStationApi().TaskEndpoint().GetInfoAsync(_gid);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/server/RdtClient.Service/Services/Downloaders/DownloadStationDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/DownloadStationDownloader.cs
@@ -1,7 +1,6 @@
 ﻿using Serilog;
 using Synology.Api.Client;
 using Synology.Api.Client.Apis.DownloadStation.Task.Models;
-using Synology.Api.Client.Apis.FileStation.List.Models;
 
 namespace RdtClient.Service.Services.Downloaders;
 
@@ -161,7 +160,10 @@ public class DownloadStationDownloader : IDownloader
     public async Task Update()
     {
         if (_gid == null)
+        {
+            DownloadComplete?.Invoke(this, new() { Error = "Task not found" });
             return;
+        }
 
         var task = await GetTask();
 
@@ -183,24 +185,6 @@ public class DownloadStationDownloader : IDownloader
             BytesTotal = task.Size,
             Speed = task.Additional.Transfer.SpeedDownload
         });
-    }
-
-    private async Task CheckFolderOrCreate(string path)
-    {
-        if (path != null)
-        {
-            try
-            {
-                await _synologyClient.FileStationApi().ListEndpoint()
-                    .ListAsync(new FileStationListRequest(path));
-            }
-            catch // if not exists create it
-            {
-                await _synologyClient.FileStationApi().CreateFolderEndpoint()
-                        .CreateAsync(new[] { path }, true);
-                //if error handle by the caller
-            }
-        }
     }
 
     private async Task<DownloadStationTask?> GetTask()

--- a/server/RdtClient.Service/Services/Downloaders/DownloadStationDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/DownloadStationDownloader.cs
@@ -59,7 +59,7 @@ public class DownloadStationDownloader : IDownloader
             }
             else
             {
-                remotePath = Path.Combine(downloadPath, category, downloadPath).Replace('\\', '/');
+                remotePath = Path.Combine(rootPath, category, downloadPath).Replace('\\', '/');
             }
         }
 

--- a/server/RdtClient.Service/Services/Downloaders/DownloadStationDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/DownloadStationDownloader.cs
@@ -109,9 +109,10 @@ public class DownloadStationDownloader : IDownloader
                     .TaskEndpoint()
                     .CreateAsync(new DownloadStationTaskCreateRequest(_uri, path.Substring(1)));
 
-                _logger.Debug($"Added download to DownloadStation, received ID {_gid}");
 
                 _gid = createResult.TaskId?.FirstOrDefault();
+                _logger.Debug($"Added download to DownloadStation, received ID {_gid}");
+
                 if (_gid == null) _gid = await GetGidFromUri();
 
                 if (_gid != null)

--- a/server/RdtClient.Service/Services/Downloaders/DownloadStationDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/DownloadStationDownloader.cs
@@ -33,9 +33,16 @@ public class DownloadStationDownloader : IDownloader
 
     public static async Task<DownloadStationDownloader> Init(String? gid, String uri, String filePath, String downloadPath, String? category)
     {
+        if (Settings.Get.DownloadClient.DownloadStationUrl == null)
+        {
+            throw new("No URL specified for Synology download station");
+        }
+        if (Settings.Get.DownloadClient.DownloadStationUsername == null || Settings.Get.DownloadClient.DownloadStationPassword == null)
+        {
+            throw new("No username/password specified for Synology download station");
+        }
         var synologyClient = new SynologyClient(Settings.Get.DownloadClient.DownloadStationUrl);
-        if (Settings.Get.DownloadClient.DownloadStationUsername != null && Settings.Get.DownloadClient.DownloadStationPassword != null)
-            await synologyClient.LoginAsync(Settings.Get.DownloadClient.DownloadStationUsername, Settings.Get.DownloadClient.DownloadStationPassword);
+        await synologyClient.LoginAsync(Settings.Get.DownloadClient.DownloadStationUsername, Settings.Get.DownloadClient.DownloadStationPassword);
 
         String? remotePath = null;
         String? rootPath;

--- a/server/RdtClient.sln
+++ b/server/RdtClient.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RdtClient.Service", "RdtCli
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RdtClient.Data", "RdtClient.Data\RdtClient.Data.csproj", "{92EF8817-AD73-4301-93BD-745D7D61DD74}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Synology.Api.Client", "..\..\Synology.Api.Client\src\Synology.Api.Client\Synology.Api.Client.csproj", "{FDAAD49C-126C-4612-81C2-3CEB6D7A1105}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{92EF8817-AD73-4301-93BD-745D7D61DD74}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{92EF8817-AD73-4301-93BD-745D7D61DD74}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{92EF8817-AD73-4301-93BD-745D7D61DD74}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDAAD49C-126C-4612-81C2-3CEB6D7A1105}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDAAD49C-126C-4612-81C2-3CEB6D7A1105}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDAAD49C-126C-4612-81C2-3CEB6D7A1105}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDAAD49C-126C-4612-81C2-3CEB6D7A1105}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/server/RdtClient.sln
+++ b/server/RdtClient.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RdtClient.Service", "RdtCli
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RdtClient.Data", "RdtClient.Data\RdtClient.Data.csproj", "{92EF8817-AD73-4301-93BD-745D7D61DD74}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Synology.Api.Client", "..\..\Synology.Api.Client\src\Synology.Api.Client\Synology.Api.Client.csproj", "{FDAAD49C-126C-4612-81C2-3CEB6D7A1105}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,10 +27,6 @@ Global
 		{92EF8817-AD73-4301-93BD-745D7D61DD74}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{92EF8817-AD73-4301-93BD-745D7D61DD74}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{92EF8817-AD73-4301-93BD-745D7D61DD74}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FDAAD49C-126C-4612-81C2-3CEB6D7A1105}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FDAAD49C-126C-4612-81C2-3CEB6D7A1105}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FDAAD49C-126C-4612-81C2-3CEB6D7A1105}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FDAAD49C-126C-4612-81C2-3CEB6D7A1105}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hey there,

I've added a new download client to the rdt-client: the Synology Download Station! It should now support managing downloads through Synology devices.

This feature has been tested with RealDebrid from early October until the recent RealDebrid update. Since then, I've tested it with AllDebrid, and it's working smoothly.

One thing I've noticed while working on this is that sometimes the application creates subfolders for downloads, but other times it doesn’t. Is this normal behavior? If not, could you clarify how it's supposed to work?

Looking forward to your feedback!