### PR TITLE
Proposition : Add request date on table for sorting

### DIFF
--- a/client/src/app/torrent-table/torrent-table.component.html
+++ b/client/src/app/torrent-table/torrent-table.component.html
@@ -20,6 +20,7 @@
         <th (click)="sort('files.length')">Files</th>
         <th (click)="sort('downloads.length')">Downloads</th>
         <th (click)="sort('rdSize')">Size</th>
+        <th (click)="sort('added')">Requested</th>
         <th (click)="sort('status')">Status</th>
       </tr>
     </thead>
@@ -52,6 +53,9 @@
         </td>
         <td>
           {{ torrent.rdSize | filesize }}
+        </td>
+        <td>
+          {{ torrent.added | date : 'medium' }}
         </td>
         <td>
           {{ torrent | status }}


### PR DESCRIPTION
I often check rdt-client to know what I have downloaded, mostly because it keep me log-in and is very fast compared to all the **arr.
I want to be able to sort by request date so I made some change and here is my proposition : 

![image](https://github.com/user-attachments/assets/8ca8ab25-ed41-4314-a6a8-a1e9049dc826)
