### PR TITLE
[Fix] Revert changes to `DownloadHelper`, move AD-symlink specific fixes to `AllDebridTorrentClient.GetSymlinkPath`

### DIFF
--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -15,20 +15,15 @@ public static class DownloadHelper
         }
 
         var directory = RemoveInvalidPathChars(torrent.RdName);
-
-        var uri = new Uri(fileUrl);
+        
         var torrentPath = Path.Combine(downloadPath, directory);
 
-        var fileName = download.FileName;
+        var fileName = GetFileName(download);
 
-        if (String.IsNullOrWhiteSpace(fileName))
+        if (fileName == null)
         {
-            fileName = uri.Segments.Last();
-
-            fileName = HttpUtility.UrlDecode(fileName);
+            return null;
         }
-
-        fileName = FileHelper.RemoveInvalidFileNameChars(fileName);
 
         var matchingTorrentFiles = torrent.Files.Where(m => m.Path.EndsWith(fileName)).Where(m => !String.IsNullOrWhiteSpace(m.Path)).ToList();
 
@@ -98,7 +93,24 @@ public static class DownloadHelper
         return filePath;
     }
 
-    private static String RemoveInvalidPathChars(String path)
+    public static String? GetFileName(Download download)
+    {
+        if (String.IsNullOrWhiteSpace(download.Link))
+        {
+            return null;
+        }
+
+        var fileName = download.FileName;
+
+        if (String.IsNullOrWhiteSpace(fileName))
+        {
+            fileName = HttpUtility.UrlDecode(new Uri(download.Link).Segments.Last());
+        }
+
+        return FileHelper.RemoveInvalidFileNameChars(fileName);
+    }
+
+    public static String RemoveInvalidPathChars(String path)
     {
         return String.Concat(path.Split(Path.GetInvalidPathChars()));
     }

--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -17,6 +17,7 @@ public static class DownloadHelper
         var directory = RemoveInvalidPathChars(torrent.RdName);
 
         var uri = new Uri(fileUrl);
+        var torrentPath = Path.Combine(downloadPath, directory);
 
         var fileName = download.FileName;
 
@@ -29,42 +30,14 @@ public static class DownloadHelper
 
         fileName = FileHelper.RemoveInvalidFileNameChars(fileName);
 
-        var torrentPath = downloadPath;
+        var matchingTorrentFiles = torrent.Files.Where(m => m.Path.EndsWith(fileName)).Where(m => !String.IsNullOrWhiteSpace(m.Path)).ToList();
 
-        if (torrent.Files.Count > 1)
+        if (matchingTorrentFiles.Count > 0)
         {
-            torrentPath = Path.Combine(downloadPath, directory);
+            var matchingTorrentFile = matchingTorrentFiles[0];
 
-            var matchingTorrentFiles = torrent.Files.Where(m => m.Path.EndsWith(fileName)).Where(m => !String.IsNullOrWhiteSpace(m.Path)).ToList();
+            var subPath = Path.GetDirectoryName(matchingTorrentFile.Path);
 
-            if (matchingTorrentFiles.Count > 0)
-            {
-                var matchingTorrentFile = matchingTorrentFiles[0];
-                var subPath = Path.GetDirectoryName(matchingTorrentFile.Path);
-
-                if (!String.IsNullOrWhiteSpace(subPath))
-                {
-                    subPath = subPath.Trim('/').Trim('\\');
-
-                    torrentPath = Path.Combine(torrentPath, subPath);
-                }
-            }
-        }
-        else if (torrent.Files.Count == 1)
-        {
-            // Debrid servers such as RealDebrid store single file torrents in a subfolder, but AllDebrid doesn't.
-            // We should replicate this behavior so that both folder structures are equal.
-            // See issue: https://github.com/rogerfar/rdt-client/issues/648
-            if (torrent.ClientKind != Torrent.TorrentClientKind.AllDebrid)
-            {
-                torrentPath = Path.Combine(downloadPath, directory);
-            }
-            
-            var torrentFile = torrent.Files[0];
-            var subPath = Path.GetDirectoryName(torrentFile.Path);
-            
-            // What we think is a single file torrent may also be a folder with a single file in it.
-            // So make sure we handle that here. If this is not the case, torrentPath will be empty below.
             if (!String.IsNullOrWhiteSpace(subPath))
             {
                 subPath = subPath.Trim('/').Trim('\\');
@@ -73,7 +46,7 @@ public static class DownloadHelper
             }
         }
 
-        if (!String.IsNullOrWhiteSpace(torrentPath) && !Directory.Exists(torrentPath))
+        if (!Directory.Exists(torrentPath))
         {
             Directory.CreateDirectory(torrentPath);
         }
@@ -85,7 +58,44 @@ public static class DownloadHelper
 
     public static String? GetDownloadPath(Torrent torrent, Download download)
     {
-        return GetDownloadPath("", torrent, download);
+        var fileUrl = download.Link;
+
+        if (String.IsNullOrWhiteSpace(fileUrl) || torrent.RdName == null)
+        {
+            return null;
+        }
+
+        var uri = new Uri(fileUrl);
+        var torrentPath = RemoveInvalidPathChars(torrent.RdName);
+
+        var fileName = download.FileName;
+
+        if (String.IsNullOrWhiteSpace(fileName))
+        {
+            fileName = uri.Segments.Last();
+
+            fileName = HttpUtility.UrlDecode(fileName);
+        }
+
+        var matchingTorrentFiles = torrent.Files.Where(m => m.Path.EndsWith(fileName)).Where(m => !String.IsNullOrWhiteSpace(m.Path)).ToList();
+
+        if (matchingTorrentFiles.Count > 0)
+        {
+            var matchingTorrentFile = matchingTorrentFiles[0];
+
+            var subPath = Path.GetDirectoryName(matchingTorrentFile.Path);
+
+            if (!String.IsNullOrWhiteSpace(subPath))
+            {
+                subPath = subPath.Trim('/').Trim('\\');
+
+                torrentPath = Path.Combine(torrentPath, subPath);
+            }
+        }
+
+        var filePath = Path.Combine(torrentPath, fileName);
+
+        return filePath;
     }
 
     private static String RemoveInvalidPathChars(String path)

--- a/server/RdtClient.Service/Services/DownloadClient.cs
+++ b/server/RdtClient.Service/Services/DownloadClient.cs
@@ -45,7 +45,7 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
                 throw new("Invalid download path");
             }
 
-            var symlinkPath = torrent.ClientKind switch
+            var symlinkSourcePath = torrent.ClientKind switch
             {
                 Torrent.TorrentClientKind.AllDebrid => AllDebridTorrentClient.GetSymlinkPath(torrent, download),
                 _ => downloadPath
@@ -63,7 +63,7 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
                 Data.Enums.DownloadClient.Internal => new InternalDownloader(download.Link, filePath),
                 Data.Enums.DownloadClient.Bezzad => new BezzadDownloader(download.Link, filePath),
                 Data.Enums.DownloadClient.Aria2c => new Aria2cDownloader(download.RemoteId, download.Link, filePath, downloadPath, category),
-                Data.Enums.DownloadClient.Symlink => new SymlinkDownloader(download.Link, filePath, symlinkPath, torrent.ClientKind),
+                Data.Enums.DownloadClient.Symlink => new SymlinkDownloader(download.Link, filePath, symlinkSourcePath, torrent.ClientKind),
                 _ => throw new($"Unknown download client {Type}")
             };
 

--- a/server/RdtClient.Service/Services/DownloadClient.cs
+++ b/server/RdtClient.Service/Services/DownloadClient.cs
@@ -1,6 +1,7 @@
 ﻿using RdtClient.Data.Models.Data;
 using RdtClient.Service.Helpers;
 using RdtClient.Service.Services.Downloaders;
+using RdtClient.Service.Services.TorrentClients;
 
 namespace RdtClient.Service.Services;
 
@@ -44,6 +45,12 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
                 throw new("Invalid download path");
             }
 
+            var symlinkPath = torrent.ClientKind switch
+            {
+                Torrent.TorrentClientKind.AllDebrid => AllDebridTorrentClient.GetSymlinkPath(torrent, download),
+                _ => downloadPath
+            };
+
             Type = torrent.DownloadClient;
 
             if (Type != Data.Enums.DownloadClient.Symlink)
@@ -56,7 +63,7 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
                 Data.Enums.DownloadClient.Internal => new InternalDownloader(download.Link, filePath),
                 Data.Enums.DownloadClient.Bezzad => new BezzadDownloader(download.Link, filePath),
                 Data.Enums.DownloadClient.Aria2c => new Aria2cDownloader(download.RemoteId, download.Link, filePath, downloadPath, category),
-                Data.Enums.DownloadClient.Symlink => new SymlinkDownloader(download.Link, filePath, downloadPath, torrent.ClientKind),
+                Data.Enums.DownloadClient.Symlink => new SymlinkDownloader(download.Link, filePath, symlinkPath, torrent.ClientKind),
                 _ => throw new($"Unknown download client {Type}")
             };
 


### PR DESCRIPTION
Hopefully fixes #671 

The changes to get AllDebrid+Symlink Downloader to work with all structures of torrents has caused other users issues.
Since the logic in `DownloadHelper` was changed (which is used for every Downloader), some users' files are ending up in the wrong place in `/data/downloads` (or wherever their downloads end up).

This PR reverts the changes to `DownloadHelper` and introduces a new variable in `DownloadClient.cs` - `symlinkSourcePath`. For every downloader other than `AD`, `symlinkSourcePath` is just `downloadPath` - exactly the same as v2.0.94. But for torrents with `TorrentClientKind.AllDebrid`, we use the static `AllDebridTorrentClient.GetSymlinkPath` to get the exact path to where we expect the file to show up in the user's rclone mount.

Ideally, this would be expanded to other debrid providers so we don't have to do *any* searching for files in the user's rclone mount, but this PR is a good enough first step.

I've tested with `Name Mismatch (single file)`, `TestSingle.txt`, `TestMultiple`, and `TestSingleInSub` with AllDebrid+Symlink Downloader - they all work.

I can't test with RD/Premiumize (which most of the users in the issue seem to use), but I have tested with AD+Internal Downloader, and everything seems OK - `GET http://rdt/api/v2/torrents/info` gives back data that looks correct, and the files end up in their own folders , so sonarr/radarr *should* work fine.

[This diff](https://github.com/rogerfar/rdt-client/compare/v2.0.94..cucumberrbob:fix/bad-download-path#diff-d7e6803838cfd79a89aea8bb7ae6de4e38001747c5cb0e7ce513b8aef62a1d51) of `DownloadHelper.cs` between v2.0.94 and this PR may be helpful, as the diff in this PR is a little noisy.