### PR TITLE
[PM] [TB] Fix: Implement `IncludeRegex`, `ExcludeRegex`, and `DownloadMinSize` 

### DIFF
--- a/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
@@ -295,7 +295,7 @@ public class PremiumizeTorrentClient(ILogger<PremiumizeTorrentClient> logger, IH
                     {
                         if (item.Link.Length < torrent.DownloadMinSize * 1024 * 1024)
                         {
-                            Log($"Not downloading {item.Name}, its size of {item.Link.Length} bytes is smaller than the minimum size of {torrent.DownloadMinSize} bytes");
+                            Log($"Not downloading {item.Name}, its size of {item.Link.Length} bytes is smaller than the minimum size of {torrent.DownloadMinSize} bytes", torrent);
 
                             continue;
                         }
@@ -305,7 +305,7 @@ public class PremiumizeTorrentClient(ILogger<PremiumizeTorrentClient> logger, IH
                     {
                         if (!Regex.IsMatch(item.Name, torrent.IncludeRegex))
                         {
-                            Log($"Not downloading {item.Name}, it does not match regex {torrent.IncludeRegex}");
+                            Log($"Not downloading {item.Name}, it does not match regex {torrent.IncludeRegex}", torrent);
 
                             continue;
                         }
@@ -314,7 +314,7 @@ public class PremiumizeTorrentClient(ILogger<PremiumizeTorrentClient> logger, IH
                     {
                         if (Regex.IsMatch(item.Name, torrent.ExcludeRegex))
                         {
-                            Log($"Not downloading {item.Name}, it matches regex {torrent.ExcludeRegex}");
+                            Log($"Not downloading {item.Name}, it matches regex {torrent.ExcludeRegex}", torrent);
 
                             continue;
                         }

--- a/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using PremiumizeNET;
 using RdtClient.Data.Enums;
@@ -287,6 +288,39 @@ public class PremiumizeTorrentClient(ILogger<PremiumizeTorrentClient> logger, IH
             if (!String.IsNullOrWhiteSpace(item.Link))
             {
                 Log($"Found item {item.Name} in folder {folder.Name} ({folderId}) with link {item.Link}", torrent);
+
+                if (item.Type == "file")
+                {
+                    if (torrent.DownloadMinSize > 0)
+                    {
+                        if (item.Link.Length < torrent.DownloadMinSize * 1024 * 1024)
+                        {
+                            Log($"Not downloading {item.Name}, its size of {item.Link.Length} bytes is smaller than the minimum size of {torrent.DownloadMinSize} bytes");
+
+                            continue;
+                        }
+                    }
+
+                    if (!String.IsNullOrWhiteSpace(torrent.IncludeRegex))
+                    {
+                        if (!Regex.IsMatch(item.Name, torrent.IncludeRegex))
+                        {
+                            Log($"Not downloading {item.Name}, it does not match regex {torrent.IncludeRegex}");
+
+                            continue;
+                        }
+                    }
+                    else if (!String.IsNullOrWhiteSpace(torrent.ExcludeRegex))
+                    {
+                        if (Regex.IsMatch(item.Name, torrent.ExcludeRegex))
+                        {
+                            Log($"Not downloading {item.Name}, it matches regex {torrent.ExcludeRegex}");
+
+                            continue;
+                        }
+                    }
+                }
+
                 downloadLinks.Add(item.Link);
             }
             else

--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -6,6 +6,7 @@ using RdtClient.Data.Enums;
 using RdtClient.Data.Models.TorrentClient;
 using System.Web;
 using RdtClient.Data.Models.Data;
+using RdtClient.Service.Helpers;
 
 namespace RdtClient.Service.Services.TorrentClients;
 
@@ -289,19 +290,37 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
 
         var selectedFiles = torrent.Files.Where(file =>
         {
+            var fileName = Path.GetFileName(file.Path);
+
             if (torrent.DownloadMinSize > 0 && file.Bytes < torrent.DownloadMinSize * 1024 * 1024)
             {
+                Log($"Not downloading {fileName}, its size of {file.Bytes} bytes is smaller than the minimum size of {torrent.DownloadMinSize} bytes", torrent);
+
                 return false;
             }
 
             if (!String.IsNullOrWhiteSpace(torrent.IncludeRegex))
             {
-                return !Regex.IsMatch(Path.GetFileName(file.Path), torrent.IncludeRegex);
+                if (!Regex.IsMatch(fileName, torrent.IncludeRegex))
+                {
+                    Log($"Not downloading {fileName}, it does not match regex {torrent.IncludeRegex}", torrent);
+
+                    return false;
+                }
+
+                // If IncludeRegex is set, don't look at ExcludeRegex
+                return true;
             }
 
             if (!String.IsNullOrWhiteSpace(torrent.ExcludeRegex))
             {
-                return Regex.IsMatch(Path.GetFileName(file.Path), torrent.ExcludeRegex);
+                if (Regex.IsMatch(fileName, torrent.ExcludeRegex))
+
+                {
+                    Log($"Not downloading {fileName}, it matches regex {torrent.ExcludeRegex}", torrent);
+
+                    return false;
+                }
             }
 
             return true;
@@ -352,5 +371,15 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
         var result = await GetClient().Torrents.GetHashInfoAsync(torrentHash, skipCache: true);
 
         return Map(result!);
+    }
+    
+    private void Log(String message, Torrent? torrent = null)
+    {
+        if (torrent != null)
+        {
+            message = $"{message} {torrent.ToLog()}";
+        }
+
+        logger.LogDebug(message);
     }
 }


### PR DESCRIPTION
Fixes #672  (I think - will know more when issue author replies) by adding logic to exclude files matching `ExcludeRegex`/not matching `IncludeRegex`/smaller than `DownloadMinSize`

`AD` and `RD` both use `IncludeRegex`, `ExcludeRegex` and `DownloadMinSize` to decide which files to download in `SelectFiles` and `GetDownloadLinks` respectively. `TB` and `PM` do not, so they won't listen to the include/exclude regex options.
This `SelectFiles`  behaviour seems to be unique to RD - that before the torrent has been downloaded, you can tell RD which files you want downloaded. Other debrid services will always download the entire torrent.

I think this part of the system (selecting files) could probably do with a refactor, maybe by changing `ITorrentClient#GetDownloadLinks` for something else, say `GetDownloadInfos`, which returns a list of 
```
{
  FileName: string;
  Link: string;
  Bytes: number
}
```
 That way we could do the filtering once in [`Torrents#CreateDownloads`](https://github.com/rogerfar/rdt-client/blob/dc2ec486d7a9c5d95da47af74646588e83dc3682/server/RdtClient.Service/Services/Torrents.cs#L223) rather than in each client.
 
 But for now, this should fix the user's issue in #672, and follows the existing pattern. So we can worry about refactoring in v3