### PR TITLE
Actually use `GetSymlinkPath` logic

### DIFF
--- a/server/RdtClient.Service/Services/DownloadClient.cs
+++ b/server/RdtClient.Service/Services/DownloadClient.cs
@@ -33,6 +33,8 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
 
         try
         {
+            Type = torrent.DownloadClient;
+
             if (download.Link == null)
             {
                 throw new($"Invalid download link");
@@ -56,7 +58,6 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
                 throw new("Invalid download path");
             }
 
-            Type = torrent.DownloadClient;
 
             if (Type != Data.Enums.DownloadClient.Symlink)
             {

--- a/server/RdtClient.Service/Services/DownloadClient.cs
+++ b/server/RdtClient.Service/Services/DownloadClient.cs
@@ -58,7 +58,6 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
                 throw new("Invalid download path");
             }
 
-
             if (Type != Data.Enums.DownloadClient.Symlink)
             {
                 await FileHelper.Delete(filePath);

--- a/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
@@ -191,7 +191,7 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
                 torrent.RdSize = torrentClientTorrent.Bytes;
             }
 
-            if (torrentClientTorrent.Files != null)
+            if (torrentClientTorrent.Files != null && torrentClientTorrent.Files.Any())
             {
                 torrent.RdFiles = JsonConvert.SerializeObject(torrentClientTorrent.Files);
             }
@@ -248,6 +248,7 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
         var allFiles = await GetClient().Magnet.FilesAsync(Int64.Parse(torrent.RdId));
 
         var files = GetFiles(allFiles);
+        // torrent.RdFiles = JsonConvert.SerializeObject(files);
 
         Log($"Getting download links", torrent);
 

--- a/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
@@ -248,7 +248,6 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
         var allFiles = await GetClient().Magnet.FilesAsync(Int64.Parse(torrent.RdId));
 
         var files = GetFiles(allFiles);
-        // torrent.RdFiles = JsonConvert.SerializeObject(files);
 
         Log($"Getting download links", torrent);
 


### PR DESCRIPTION
Fixes #713  (at least partially)

Not entirely sure why yet, but since AD silently updated how their `/v4.1/magnets/status` endpoint works when no `id` is specified (it no longer returns files), symlink path resolution for single file torrents is broken.

Turns out this is because we were always using the `downloadPath DownloadHelper.GetDownloadPath()` rather than the `AllDebridTorrentClient.GetSymlinkPath`, because `Type` was not set at that point.

I've reordered the code so `Type` is defined before it's used.

This fixes AD symlinks for single file torrents, while keeping functionality for both `DL` and `AD` for all the torrents that already worked.

I've tested with [`Torrents.zip`](https://github.com/user-attachments/files/18724545/Torrents.zip) on both `AD` and `DL`