### PR TITLE
Fix permissions sweep

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-rdt-client/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-rdt-client/run
@@ -10,4 +10,4 @@
 # permissions
 echo "Setting permissions"
 chown -R abc:abc \
-	/app /data
+	/data


### PR DESCRIPTION
### **User description**
It should not be setting permissions on data that lives in the image.

Fixes #716


___

### **PR Type**
Bug fix


___

### **Description**
- Restricts permissions setting to `/data` directory only

- Prevents unnecessary chown on `/app` during container startup

- Addresses Docker container startup hang issue


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run</strong><dd><code>Restrict chown operation to /data directory only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

root/etc/s6-overlay/s6-rc.d/init-rdt-client/run

<li>Removes <code>/app</code> from the recursive chown command<br> <li> Now only <code>/data</code> has its ownership set to <code>abc:abc</code><br> <li> Prevents permission changes on image-internal files


</details>


  </td>
  <td><a href="https://github.com/rogerfar/rdt-client/pull/717/files#diff-6186e1a379d9cb7a4c5adc8e582f10bca9ba7e3142ab25b824417e951c27a4bb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>