### PR TITLE
Use `TheoryData<>` instead of `Object[]` for theory data

### DIFF
--- a/server/RdtClient.Service.Test/Services/TorrentClients/AllDebridTorrentClientTest.cs
+++ b/server/RdtClient.Service.Test/Services/TorrentClients/AllDebridTorrentClientTest.cs
@@ -294,9 +294,17 @@ public class AllDebridTorrentClientTest
         Assert.Contains(secondResult, t => t.Id == Magnet2Finished.Id.ToString());
     }
 
-    public static IEnumerable<Object[]> DownloadingMagnetsWithProgress()
+    public static TheoryData<Magnet, Int64> DownloadingMagnetsWithProgress()
     {
-        return [[Magnet1HalfDownloaded, 50], [Magnet2QuarterDownloaded, 25]];
+        return new()
+        {
+            {
+                Magnet1HalfDownloaded, 50
+            },
+            {
+                Magnet2QuarterDownloaded, 25
+            }
+        };
     }
 
     [Theory]

--- a/server/RdtClient.Service.Test/Services/TorrentsTest.cs
+++ b/server/RdtClient.Service.Test/Services/TorrentsTest.cs
@@ -38,7 +38,7 @@ class Mocks
 
 public class TorrentsTest
 {
-    public static IEnumerable<Object[]> TorrentAndDownload()
+    public static TheoryData<Torrent, List<Download>> TorrentAndDownload()
     {
         var torrent = new Torrent()
         {
@@ -58,10 +58,13 @@ public class TorrentsTest
             }
         ];
 
-        yield return
-        [
-            torrent, downloads
-        ];
+        return new ()
+        {
+            {
+              torrent,
+              downloads
+            }
+        };
     }
 
     [Theory]


### PR DESCRIPTION
Per feedback in #691 uses `TheoryData<>` for better type safety in tests.