### PR TITLE
[TB] Update TorBox.NET to 1.5.0

### DIFF
--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Synology.Api.Client" Version="0.3.91" />
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.0.10" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.10" />
-    <PackageReference Include="TorBox.NET" Version="1.4.0" />
+    <PackageReference Include="TorBox.NET" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates TorBox.NET to 1.5.0 to expose interfaces (https://github.com/asylumexp/TorBox.NET/pull/2)