### PR TITLE
refactor!: DRY Download Filtering 

### DIFF
--- a/server/RdtClient.Service.Test/Services/DownloadableFileFilterTest.cs
+++ b/server/RdtClient.Service.Test/Services/DownloadableFileFilterTest.cs
@@ -1,0 +1,261 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using RdtClient.Data.Models.Data;
+using RdtClient.Service.Services;
+
+namespace RdtClient.Service.Test.Services;
+
+public class DownloadableFileFilterTest
+{
+    [Fact]
+    public void IsDownloadable_WhenNoFilterSpecified_ReturnsTrue()
+    {
+        // Arrange
+        var mocks = new Mocks();
+
+        var torrent = new Torrent
+        {
+            RdId = "1"
+        };
+        
+        var fileFilter = new DownloadableFileFilter(mocks.LoggerMock.Object);
+
+        // Act
+        var result = fileFilter.IsDownloadable(torrent, "file.txt", 10000);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    // downloadMinSize is in MB, fileSize is in B
+    [InlineData(100, 20 * 1024 * 1024)]
+    [InlineData(2,   2 * 1024 * 1024)]
+    [InlineData(2,   2 * (1000 * 1000 + 1))] // mostly to show we use 1024 not 1000 for conversion
+    public void IsDownloadable_WhenDownloadMinSizeSpecified_AndDownloadBelowSize_ReturnsFalse(Int32 downloadMinSize, Int64 fileSize)
+    {
+        // Arrange
+        var mocks = new Mocks();
+
+        var torrent = new Torrent
+        {
+            RdId = "1",
+            DownloadMinSize = downloadMinSize
+        };
+
+        var fileFilter = new DownloadableFileFilter(mocks.LoggerMock.Object);
+
+        // Act
+        var result = fileFilter.IsDownloadable(torrent, "file.txt", fileSize);
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Theory]
+    [InlineData(100, 110 * 1024 * 1024)]
+    [InlineData(2,   2 * 1024 * 1024 + 1)]
+    public void IsDownloadable_WhenDownloadMinSizeSpecified_AndDownloadAboveSize_ReturnsTrue(Int32 downloadMinSize, Int64 fileSize)
+    {
+        // Arrange
+        var mocks = new Mocks();
+
+        var torrent = new Torrent
+        {
+            RdId = "1",
+            DownloadMinSize = downloadMinSize
+        };
+
+        var fileFilter = new DownloadableFileFilter(mocks.LoggerMock.Object);
+
+        // Act
+        var result = fileFilter.IsDownloadable(torrent, "file.txt", fileSize);
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Theory]
+    [InlineData("file", "no-match")]
+    [InlineData("file", "even/in/a/subdirectory.txt")]
+    [InlineData("ch[aA]racter c[lL]asses", "nope.txt")]
+    [InlineData("digits\\d+", "123 not matching.txt")]
+    public void IsDownloadable_WhenIncludeRegexSpecified_AndPathDoesNotMatchRegex_ReturnsFalse(String includeRegex, String filePath)
+    {
+        // Arrange
+        var mocks = new Mocks();
+
+        var torrent = new Torrent
+        {
+            RdId = "1",
+            IncludeRegex = includeRegex
+        };
+
+        var fileFilter = new DownloadableFileFilter(mocks.LoggerMock.Object);
+
+        // Act
+        var result = fileFilter.IsDownloadable(torrent, filePath, Int64.MaxValue);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("file", "file.txt")]
+    [InlineData("file", "file/in/a/subdirectory.txt")]
+    [InlineData("ch[aA]racter c[lL]asses", "character cLasses")]
+    [InlineData("digits\\d+", "digits123456.txt")]
+    public void IsDownloadable_WhenIncludeRegexSpecified_AndPathMatchesRegex_ReturnsTrue(String includeRegex, String filePath)
+    {
+        // Arrange
+        var mocks = new Mocks();
+
+        var torrent = new Torrent
+        {
+            RdId = "1",
+            IncludeRegex = includeRegex
+        };
+
+        var fileFilter = new DownloadableFileFilter(mocks.LoggerMock.Object);
+
+        // Act
+        var result = fileFilter.IsDownloadable(torrent, filePath, Int64.MaxValue);
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Theory]
+    [InlineData("file", "no-match")]
+    [InlineData("file", "even/in/a/subdirectory.txt")]
+    [InlineData("ch[aA]racter c[lL]asses", "nope.txt")]
+    [InlineData("digits\\d+", "123 not matching.txt")]
+    public void IsDownloadable_WhenExcludeRegexSpecified_AndPathDoesNotMatchRegex_ReturnsTrue(String excludeRegex, String filePath)
+    {
+        // Arrange
+        var mocks = new Mocks();
+
+        var torrent = new Torrent
+        {
+            RdId = "1",
+            ExcludeRegex = excludeRegex
+        };
+
+        var fileFilter = new DownloadableFileFilter(mocks.LoggerMock.Object);
+
+        // Act
+        var result = fileFilter.IsDownloadable(torrent, filePath, Int64.MaxValue);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("file", "file.txt")]
+    [InlineData("file", "file/in/a/subdirectory.txt")]
+    [InlineData("ch[aA]racter c[lL]asses", "character cLasses")]
+    [InlineData("digits\\d+", "digits123456.txt")]
+    public void IsDownloadable_WhenExcludeRegexSpecified_AndPathMatchesRegex_ReturnsFalse(String excludeRegex, String filePath)
+    {
+        // Arrange
+        var mocks = new Mocks();
+
+        var torrent = new Torrent
+        {
+            RdId = "1",
+            ExcludeRegex = excludeRegex
+        };
+
+        var fileFilter = new DownloadableFileFilter(mocks.LoggerMock.Object);
+
+        // Act
+        var result = fileFilter.IsDownloadable(torrent, filePath, Int64.MaxValue);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("file", "file", "file.txt")]
+    [InlineData("file", "in/a", "file/in/a/subdirectory.txt")]
+    [InlineData("ch[aA]racter c[lL]asses", "character", "character cLasses")]
+    [InlineData("digits\\d+", "123456", "digits123456.txt")]
+    public void IsDownloadable_WhenBothIncludeAndExcludeRegexSpecified_AndPathMatchesIncludeAndExcludeRegex_ReturnsTrue(String includeRegex, String excludeRegex, String filePath)
+    {
+        // Arrange
+        var mocks = new Mocks();
+
+        var torrent = new Torrent
+        {
+            RdId = "1",
+            IncludeRegex = includeRegex,
+            ExcludeRegex = excludeRegex
+        };
+
+        var fileFilter = new DownloadableFileFilter(mocks.LoggerMock.Object);
+
+        // Act
+        var result = fileFilter.IsDownloadable(torrent, filePath, Int64.MaxValue);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(10, "file", 10 * 1024 * 1024 + 1, "no-match.txt")]
+    public void IsDownloadable_WhenBothDownloadMinSizeAndIncludeRegexSpecified_AndDownloadAboveSizeAndDoesNotMatchRegex_ReturnsFalse(
+        Int32 minSize,
+        String includeRegex,
+        Int64 fileSize,
+        String filePath)
+    {
+        // Arrange
+        var mocks = new Mocks();
+        
+        var torrent = new Torrent
+        {
+            RdId = "1",
+            IncludeRegex = includeRegex,
+            DownloadMinSize = minSize
+        };
+        
+        var fileFilter = new DownloadableFileFilter(mocks.LoggerMock.Object);
+
+        // Act
+        var result = fileFilter.IsDownloadable(torrent, filePath, fileSize);
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Theory]
+    [InlineData(10, "file", 10 * 1024 * 1024 - 1, "file.txt")]
+    public void IsDownloadable_WhenBothDownloadMinSizeAndIncludeRegexSpecified_AndDownloadBelowSizeAndMatchesRegex_ReturnsFalse(
+        Int32 minSize,
+        String includeRegex,
+        Int64 fileSize,
+        String filePath)
+    {
+        // Arrange
+        var mocks = new Mocks();
+        
+        var torrent = new Torrent
+        {
+            RdId = "1",
+            IncludeRegex = includeRegex,
+            DownloadMinSize = minSize
+        };
+        
+        var fileFilter = new DownloadableFileFilter(mocks.LoggerMock.Object);
+
+        // Act
+        var result = fileFilter.IsDownloadable(torrent, filePath, fileSize);
+
+        // Assert
+        Assert.False(result);
+    }
+    private class Mocks
+    {
+        public readonly Mock<ILogger<DownloadableFileFilter>> LoggerMock = new();
+    }
+}

--- a/server/RdtClient.Service.Test/Services/TorrentClients/AllDebridTorrentClientTest.cs
+++ b/server/RdtClient.Service.Test/Services/TorrentClients/AllDebridTorrentClientTest.cs
@@ -4,6 +4,7 @@ using Moq;
 using Newtonsoft.Json;
 using RdtClient.Data.Enums;
 using RdtClient.Data.Models.Data;
+using RdtClient.Service.Services;
 using RdtClient.Service.Services.TorrentClients;
 using File = AllDebridNET.File;
 
@@ -69,60 +70,6 @@ public class AllDebridTorrentClientTest
         CompletionDate = new DateTimeOffset(2020, 1, 1, 1, 5, 0, TimeSpan.Zero).Second
     };
 
-    private static readonly List<File> IncludeExcludeFiles =
-    [
-        new()
-        {
-            FolderOrFileName = "include.txt",
-            Size = 1,
-            DownloadLink = "https://fake.url/include.txt"
-        },
-        new()
-        {
-            FolderOrFileName = "exclude.txt",
-            Size = 1,
-            DownloadLink = "https://fake.url/exclude.txt"
-        },
-        new()
-        {
-            FolderOrFileName = "include-folder",
-            SubNodes =
-            [
-                new File
-                {
-                    FolderOrFileName = "include-folder-exclude-file.txt",
-                    Size = 1,
-                    DownloadLink = "https://fake.url/include-folder-exclude-file.txt"
-                },
-                new File
-                {
-                    FolderOrFileName = "include-folder-include-file.txt",
-                    Size = 1,
-                    DownloadLink = "https://fake.url/include-folder-include-file.txt"
-                }
-            ]
-        },
-        new()
-        {
-            FolderOrFileName = "exclude-folder",
-            SubNodes =
-            [
-                new File
-                {
-                    FolderOrFileName = "exclude-folder-exclude-file.txt",
-                    Size = 1,
-                    DownloadLink = "https://fake.url/exclude-folder-exclude-file.txt"
-                },
-                new File
-                {
-                    FolderOrFileName = "exclude-folder-include-file.txt",
-                    Size = 1,
-                    DownloadLink = "https://fake.url/exclude-folder-include-file.txt"
-                }
-            ]
-        }
-    ];
-
     [Fact]
     public async Task GetTorrents_WhenFullSyncNoTorrents_ReturnsEmptyList()
     {
@@ -137,7 +84,7 @@ public class AllDebridTorrentClientTest
                  Fullsync = true
              });
 
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
         var result = await allDebridTorrentClient.GetTorrents();
@@ -167,7 +114,7 @@ public class AllDebridTorrentClientTest
                  Fullsync = false
              });
 
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
         var result = await allDebridTorrentClient.GetTorrents();
@@ -197,7 +144,7 @@ public class AllDebridTorrentClientTest
                  Fullsync = true
              });
 
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
 
@@ -233,7 +180,7 @@ public class AllDebridTorrentClientTest
                  Fullsync = false
              });
 
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
 
@@ -275,7 +222,7 @@ public class AllDebridTorrentClientTest
                  Fullsync = false
              });
 
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
 
@@ -314,7 +261,7 @@ public class AllDebridTorrentClientTest
                  Fullsync = true
              });
 
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
 
@@ -339,7 +286,7 @@ public class AllDebridTorrentClientTest
         };
 
         var serializedOriginal = JsonConvert.SerializeObject(torrent);
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
         var result = await allDebridTorrentClient.UpdateData(torrent, null);
@@ -365,7 +312,7 @@ public class AllDebridTorrentClientTest
         };
 
         mocks.AllDebridClientMock.Setup(c => c.Magnet.StatusAsync(torrent.RdId, It.IsAny<CancellationToken>())).ReturnsAsync(Magnet1Finished);
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
         var result = await allDebridTorrentClient.UpdateData(torrent, null);
@@ -398,7 +345,7 @@ public class AllDebridTorrentClientTest
         mocks.AllDebridClientMock.Setup(c => c.Magnet.StatusAsync(torrent.RdId, It.IsAny<CancellationToken>()))
              .ThrowsAsync(new AllDebridException("Magnet not found", "MAGNET_INVALID_ID"));
 
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
         var result = await allDebridTorrentClient.UpdateData(torrent, null);
@@ -433,7 +380,7 @@ public class AllDebridTorrentClientTest
                  Fullsync = true
              });
 
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
         var torrentClientTorrent = (await allDebridTorrentClient.GetTorrents()).First();
 
         // Act
@@ -460,7 +407,7 @@ public class AllDebridTorrentClientTest
             RdId = null
         };
 
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
         var result = await allDebridTorrentClient.GetDownloadLinks(torrent);
@@ -471,7 +418,57 @@ public class AllDebridTorrentClientTest
     }
 
     [Fact]
-    public async Task GetDownloadLinks_ByDefault_GetsLinksForAllFiles()
+    public async Task GetDownloadLinks_UsesFileFilter()
+    {
+        // Arrange
+        var mocks = new Mocks();
+
+        var torrent = new Torrent
+        {
+            RdId = "1"
+        };
+
+        List<File> files =
+        [
+            new()
+            {
+                FolderOrFileName = "file1.txt",
+                Size = 123,
+                DownloadLink = "https://fake.url/file1.txt"
+            },
+
+            new()
+            {
+                FolderOrFileName = "folder",
+                SubNodes =
+                [
+                    new()
+                    {
+                        FolderOrFileName = "file2.txt",
+                        Size = 180,
+                        DownloadLink = "https://fake.url/file2.txt"
+                    }
+                ]
+            }
+        ];
+
+        mocks.AllDebridClientMock.Setup(c => c.Magnet.FilesAsync(Int64.Parse(torrent.RdId), It.IsAny<CancellationToken>())).ReturnsAsync(files);
+        mocks.FileFilterMock.Setup(f => f.IsDownloadable(torrent, "file1.txt", 123)).Returns(true);
+        mocks.FileFilterMock.Setup(f => f.IsDownloadable(torrent, "folder/file2.txt", 180)).Returns(false);
+
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
+
+        // Act
+        var result = await allDebridTorrentClient.GetDownloadLinks(torrent);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Contains("https://fake.url/file1.txt", result);
+    }
+
+    [Fact]
+    public async Task GetDownloadLinks_WhenAllFilesExcluded_ReturnsAllFiles()
     {
         // Arrange
         var mocks = new Mocks();
@@ -486,20 +483,22 @@ public class AllDebridTorrentClientTest
             new()
             {
                 FolderOrFileName = "file-1.txt",
-                Size = 50,
+                Size = 100,
                 DownloadLink = "https://fake.url/file-1.txt"
             },
             new()
             {
                 FolderOrFileName = "file-2.txt",
-                Size = 150,
+                Size = 100,
                 DownloadLink = "https://fake.url/file-2.txt"
             }
         ];
 
         var expectedLinksSet = new HashSet<String>(files.Select(n => n.DownloadLink)!);
         mocks.AllDebridClientMock.Setup(c => c.Magnet.FilesAsync(Int64.Parse(torrent.RdId), It.IsAny<CancellationToken>())).ReturnsAsync(files);
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
+        mocks.FileFilterMock.Setup(f => f.IsDownloadable(torrent, It.IsAny<String>(), It.IsAny<Int64>())).Returns(false);
+
+        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object, mocks.FileFilterMock.Object);
 
         // Act
         var result = await allDebridTorrentClient.GetDownloadLinks(torrent);
@@ -508,184 +507,9 @@ public class AllDebridTorrentClientTest
         Assert.NotNull(result);
         var linksSet = new HashSet<String>(result);
         Assert.Equal(expectedLinksSet, linksSet);
-    }
 
-    [Fact]
-    public async Task GetDownloadLinks_WhenDownloadMinSizeSet_GetsLinksForOnlyFilesAboveThatSize()
-    {
-        // Arrange
-        var mocks = new Mocks();
-
-        var torrent = new Torrent
-        {
-            RdId = "1",
-
-            // NB: this is in MB, the file sizes below are in B
-            DownloadMinSize = 100
-        };
-
-        List<File> files =
-        [
-            new()
-            {
-                FolderOrFileName = "too-small.txt",
-                Size = (torrent.DownloadMinSize - 1) * 1024 * 1024,
-                DownloadLink = "https://fake.url/too-small.txt"
-            },
-            new()
-            {
-                FolderOrFileName = "bigger-than-min.txt",
-                Size = (torrent.DownloadMinSize + 1) * 1024 * 1024,
-                DownloadLink = "https://fake.url/bigger-than-min.txt"
-            }
-        ];
-
-        var expectedLinksSet = new HashSet<String>(files.Where(m => m.Size > torrent.DownloadMinSize * 1024 * 1024).Select(n => n.DownloadLink)!);
-        mocks.AllDebridClientMock.Setup(c => c.Magnet.FilesAsync(Int64.Parse(torrent.RdId), It.IsAny<CancellationToken>())).ReturnsAsync(files);
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
-
-        // Act
-        var result = await allDebridTorrentClient.GetDownloadLinks(torrent);
-
-        // Assert
-        Assert.NotNull(result);
-        var linksSet = new HashSet<String>(result);
-        Assert.Equal(expectedLinksSet, linksSet);
-    }
-
-    [Fact]
-    public async Task GetDownloadLinks_WhenIncludeRegexSet_GetsLinksForOnlyFilesMatchingRegex()
-    {
-        // Arrange
-        var mocks = new Mocks();
-
-        var torrent = new Torrent
-        {
-            RdId = "1",
-            IncludeRegex = "include"
-        };
-
-        var expectedLinksSet = new HashSet<String>([
-            "https://fake.url/include.txt", "https://fake.url/include-folder-exclude-file.txt", "https://fake.url/include-folder-include-file.txt",
-            "https://fake.url/exclude-folder-include-file.txt"
-        ]);
-
-        mocks.AllDebridClientMock.Setup(c => c.Magnet.FilesAsync(Int64.Parse(torrent.RdId), It.IsAny<CancellationToken>())).ReturnsAsync(IncludeExcludeFiles);
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
-
-        // Act
-        var result = await allDebridTorrentClient.GetDownloadLinks(torrent);
-
-        // Assert
-        Assert.NotNull(result);
-        var linksSet = new HashSet<String>(result);
-        Assert.Equal(expectedLinksSet, linksSet);
-    }
-
-    [Fact]
-    public async Task GetDownloadLinks_WhenExcludeRegexSet_GetsLinksForOnlyFilesNotMatchingRegex()
-    {
-        // Arrange
-        var mocks = new Mocks();
-
-        var torrent = new Torrent
-        {
-            RdId = "1",
-            ExcludeRegex = "exclude"
-        };
-
-        var expectedLinksSet = new HashSet<String>([
-            "https://fake.url/include.txt", "https://fake.url/include-folder-include-file.txt"
-        ]);
-
-        mocks.AllDebridClientMock.Setup(c => c.Magnet.FilesAsync(Int64.Parse(torrent.RdId), It.IsAny<CancellationToken>())).ReturnsAsync(IncludeExcludeFiles);
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
-
-        // Act
-        var result = await allDebridTorrentClient.GetDownloadLinks(torrent);
-
-        // Assert
-        Assert.NotNull(result);
-        var linksSet = new HashSet<String>(result);
-        Assert.Equal(expectedLinksSet, linksSet);
-    }
-
-    [Fact]
-    public async Task GetDownloadLinks_WhenIncludeAndExcludeRegexSet_GetsLinksForOnlyFilesMatchingIncludeRegexEvenIfNotMatchingExcludeRegex()
-    {
-        // Arrange
-        var mocks = new Mocks();
-
-        var torrentInclude = new Torrent
-        {
-            RdId = "1",
-            IncludeRegex = "include"
-        };
-
-        var torrentIncludeExclude = new Torrent
-        {
-            RdId = "2",
-            IncludeRegex = "include",
-            ExcludeRegex = "exclude"
-        };
-
-        mocks.AllDebridClientMock.Setup(c => c.Magnet.FilesAsync(It.IsAny<Int64>(), It.IsAny<CancellationToken>())).ReturnsAsync(IncludeExcludeFiles);
-
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
-
-        // Act
-        var includeOnlyResult = await allDebridTorrentClient.GetDownloadLinks(torrentInclude);
-        var includeExcludeResult = await allDebridTorrentClient.GetDownloadLinks(torrentIncludeExclude);
-
-        // Assert
-        Assert.NotNull(includeOnlyResult);
-        Assert.NotNull(includeExcludeResult);
-        var includeOnlyLinksSet = new HashSet<String>(includeOnlyResult);
-        var includeExcludeLinksSet = new HashSet<String>(includeExcludeResult);
-        Assert.Equal(includeOnlyLinksSet, includeExcludeLinksSet);
-    }
-
-    [Fact]
-    public async Task GetDownloadLinks_WhenAllFilesExcluded_ReturnsAllFiles()
-    {
-        // Arrange
-        var mocks = new Mocks();
-
-        var torrent = new Torrent
-        {
-            RdId = "1",
-
-            // NB: this is in MB, the file sizes below are in B
-            DownloadMinSize = 100
-        };
-
-        List<File> files =
-        [
-            new()
-            {
-                FolderOrFileName = "too-small-1.txt",
-                Size = (torrent.DownloadMinSize - 1) * 1024 * 1024,
-                DownloadLink = "https://fake.url/too-small-1.txt"
-            },
-            new()
-            {
-                FolderOrFileName = "too-small-2.txt",
-                Size = (torrent.DownloadMinSize - 1) * 1024 * 1024,
-                DownloadLink = "https://fake.url/too-small-2.txt"
-            }
-        ];
-
-        var expectedLinksSet = new HashSet<String>(files.Select(n => n.DownloadLink)!);
-        mocks.AllDebridClientMock.Setup(c => c.Magnet.FilesAsync(Int64.Parse(torrent.RdId), It.IsAny<CancellationToken>())).ReturnsAsync(files);
-        var allDebridTorrentClient = new AllDebridTorrentClient(mocks.LoggerMock.Object, mocks.AllDebridClientFactoryMock.Object);
-
-        // Act
-        var result = await allDebridTorrentClient.GetDownloadLinks(torrent);
-
-        // Assert
-        Assert.NotNull(result);
-        var linksSet = new HashSet<String>(result);
-        Assert.Equal(expectedLinksSet, linksSet);
+        mocks.FileFilterMock.Verify(f => f.IsDownloadable(torrent, "file-1.txt", 100));
+        mocks.FileFilterMock.Verify(f => f.IsDownloadable(torrent, "file-2.txt", 100));
     }
 
     private class Mocks
@@ -693,10 +517,12 @@ public class AllDebridTorrentClientTest
         public readonly Mock<IAllDebridNetClientFactory> AllDebridClientFactoryMock;
         public readonly Mock<IAllDebridNETClient> AllDebridClientMock;
         public readonly Mock<ILogger<AllDebridTorrentClient>> LoggerMock;
+        public readonly Mock<IDownloadableFileFilter> FileFilterMock;
 
         public Mocks()
         {
             LoggerMock = new();
+            FileFilterMock = new();
             AllDebridClientMock = new();
             AllDebridClientFactoryMock = new();
             AllDebridClientFactoryMock.Setup(f => f.GetClient()).Returns(AllDebridClientMock.Object);

--- a/server/RdtClient.Service/DiConfig.cs
+++ b/server/RdtClient.Service/DiConfig.cs
@@ -37,6 +37,8 @@ public static class DiConfig
         services.AddScoped<TorrentRunner>();
         services.AddScoped<DebridLinkClient>();
 
+        services.AddSingleton<IDownloadableFileFilter, DownloadableFileFilter>();
+
         services.AddSingleton<IAuthorizationHandler, AuthSettingHandler>();
 
         services.AddHostedService<ProviderUpdater>();

--- a/server/RdtClient.Service/Services/DownloadableFileFilter.cs
+++ b/server/RdtClient.Service/Services/DownloadableFileFilter.cs
@@ -14,8 +14,8 @@ public class DownloadableFileFilter(ILogger<DownloadableFileFilter> logger) : ID
 {
     public Boolean IsDownloadable(Torrent torrent, String filePath, Int64 fileSize)
     {
-        var isDownloadable = SatisfiesMinSize(torrent, filePath, fileSize) &&
-                             SatisfiesFileNameRegex(torrent, filePath);
+        var isDownloadable = PassesSizeFilter(torrent, filePath, fileSize) &&
+                             PassesFilePathFilter(torrent, filePath);
 
         if (isDownloadable)
         {
@@ -25,7 +25,7 @@ public class DownloadableFileFilter(ILogger<DownloadableFileFilter> logger) : ID
         return isDownloadable;
     }
 
-    private Boolean SatisfiesMinSize(Torrent torrent, String filePath, Int64 fileSize)
+    private Boolean PassesSizeFilter(Torrent torrent, String filePath, Int64 fileSize)
     {
         if (torrent is { ClientKind: Provider.RealDebrid, DownloadAction: TorrentDownloadAction.DownloadManual })
         {
@@ -42,12 +42,12 @@ public class DownloadableFileFilter(ILogger<DownloadableFileFilter> logger) : ID
         return false;
     }
 
-    private Boolean SatisfiesFileNameRegex(Torrent torrent, String filePath)
+    private Boolean PassesFilePathFilter(Torrent torrent, String filePath)
     {
-        return IncludeFileName(torrent, filePath) && ExcludeFileName(torrent, filePath);
+        return PassesIncludeRegexFilter(torrent, filePath) && PassesExcludeRegexFilter(torrent, filePath);
     }
 
-    private Boolean IncludeFileName(Torrent torrent, String filePath)
+    private Boolean PassesIncludeRegexFilter(Torrent torrent, String filePath)
     {
         if (String.IsNullOrWhiteSpace(torrent.IncludeRegex) || Regex.IsMatch(filePath, torrent.IncludeRegex))
         {
@@ -59,7 +59,7 @@ public class DownloadableFileFilter(ILogger<DownloadableFileFilter> logger) : ID
         return false;
     }
 
-    private Boolean ExcludeFileName(Torrent torrent, String filePath)
+    private Boolean PassesExcludeRegexFilter(Torrent torrent, String filePath)
     {
         // If the IncludeRegex is set, ignore the ExcludeRegex 
         if (!String.IsNullOrWhiteSpace(torrent.IncludeRegex))

--- a/server/RdtClient.Service/Services/DownloadableFileFilter.cs
+++ b/server/RdtClient.Service/Services/DownloadableFileFilter.cs
@@ -1,0 +1,79 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using RdtClient.Data.Enums;
+using RdtClient.Data.Models.Data;
+
+namespace RdtClient.Service.Services;
+
+public interface IDownloadableFileFilter
+{
+    public Boolean IsDownloadable(Torrent torrent, String filePath, Int64 fileSize);
+}
+
+public class DownloadableFileFilter(ILogger<DownloadableFileFilter> logger) : IDownloadableFileFilter
+{
+    public Boolean IsDownloadable(Torrent torrent, String filePath, Int64 fileSize)
+    {
+        var isDownloadable = SatisfiesMinSize(torrent, filePath, fileSize) &&
+                             SatisfiesFileNameRegex(torrent, filePath);
+
+        if (isDownloadable)
+        {
+            logger.LogDebug("File {filePath} was included after filtering", filePath);
+        }
+        
+        return isDownloadable;
+    }
+
+    private Boolean SatisfiesMinSize(Torrent torrent, String filePath, Int64 fileSize)
+    {
+        if (torrent is { ClientKind: Provider.RealDebrid, DownloadAction: TorrentDownloadAction.DownloadManual })
+        {
+            return true;
+        }
+
+        if (torrent.DownloadMinSize <= 0 || fileSize > torrent.DownloadMinSize * 1024 * 1024)
+        {
+            return true;
+        }
+
+        logger.LogDebug("Not downloading file {filePath} file size {fileSize} smaller than minimum {downloadMinSize}", filePath, fileSize, torrent.DownloadMinSize);
+
+        return false;
+    }
+
+    private Boolean SatisfiesFileNameRegex(Torrent torrent, String filePath)
+    {
+        return IncludeFileName(torrent, filePath) && ExcludeFileName(torrent, filePath);
+    }
+
+    private Boolean IncludeFileName(Torrent torrent, String filePath)
+    {
+        if (String.IsNullOrWhiteSpace(torrent.IncludeRegex) || Regex.IsMatch(filePath, torrent.IncludeRegex))
+        {
+            return true;
+        }
+
+        logger.LogDebug("Not downloading file {filePath} does not match regex {includeRegex}", filePath, torrent.IncludeRegex);
+
+        return false;
+    }
+
+    private Boolean ExcludeFileName(Torrent torrent, String filePath)
+    {
+        // If the IncludeRegex is set, ignore the ExcludeRegex 
+        if (!String.IsNullOrWhiteSpace(torrent.IncludeRegex))
+        {
+            return true;
+        }
+
+        if (String.IsNullOrWhiteSpace(torrent.ExcludeRegex) || !Regex.IsMatch(filePath, torrent.ExcludeRegex))
+        {
+            return true;
+        }
+
+        logger.LogDebug("Not downloading file {filePath} matches regex {excludeRegex}", filePath, torrent.ExcludeRegex);
+
+        return false;
+    }
+}

--- a/server/RdtClient.Service/Services/TorrentClients/DebridLinkTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/DebridLinkTorrentClient.cs
@@ -260,25 +260,7 @@ public class DebridLinkClient(ILogger<DebridLinkClient> logger, IHttpClientFacto
             Log($"{link}", torrent);
         }
 
-        // Check if all the links are set that have been selected
-        if (torrent.Files.Count(m => m.Selected) == downloadLinks.Count)
-        {
-            return downloadLinks;
-        }
-
-        // Check if all all the links are set for manual selection
-        if (torrent.ManualFiles.Count == downloadLinks.Count)
-        {
-            return downloadLinks;
-        }
-
-        // If there is only 1 link, delay for 1 minute to see if more links pop up.
-        if (downloadLinks.Count == 1 && torrent.RdEnded.HasValue && DateTime.UtcNow > torrent.RdEnded.Value.ToUniversalTime().AddMinutes(1))
-        {
-            return downloadLinks;
-        }
-            
-        return null;
+        return downloadLinks;
     }
 
     private async Task<TorrentClientTorrent> GetInfo(String torrentId)

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -242,6 +242,20 @@ public class Torrents(
             return;
         }
 
+        if (downloadLinks.Count == 0)
+        {
+            logger.LogInformation("All files excluded by filters (IncludeRegex: {includeRegex}, ExcludeRegex: {excludeRegex}, DownloadMinSize: {downloadMinSize}  {torrentInfo}",
+                            torrent.IncludeRegex,
+                            torrent.ExcludeRegex,
+                            torrent.DownloadMinSize,
+                            torrent.ToLog());
+
+            await torrentData.UpdateRetry(torrentId, null, torrent.TorrentRetryAttempts);
+            await torrentData.UpdateComplete(torrentId, "All files excluded", DateTimeOffset.Now, false);
+
+            return;
+        }
+
         foreach (var downloadLink in downloadLinks)
         {
             // Make sure downloads don't get added multiple times


### PR DESCRIPTION
I'm not a fan of DRY for DRY's sake, but I think this is a worthwhile abstraction.

Currently, every TorrentClient except `DebridLink` implements basically the same thing: a file filter which includes only files above `DownloadMinSize` (if nonzero) and either matching `IncludeRegex` (if present) or `ExcludeRegex` (if present and `IncludeRegex` not present).

AD and RD both currently ignore the filter if the filter would exclude all files. There seems to be some demand for this to be changed (https://github.com/rogerfar/rdt-client/issues/429#issuecomment-2433418245), so I'm willing to push a commit removing this on request (it's only a few lines). 

This PR also adds the filtering logic to `DL`, so all the `TorrentClients` will not only download fiels matching the filter.
I chose to listen to the filter if all files would be excluding. As above, I can push a commit changing this on request.

I've changed the tests for `AllDebridTorrentClient` so they mock responses from the file filter rather than checking the filter itself works.
And I've added tests for `DownloadableFileFilter` itself.

I'm not overly attached to the name `IsDownloadable`. Here are some other ideas:
- `ShouldDownload`
- `IsIncluded`
- `MatchesFilter`

This could potentially also be a method on the torrent itself, like `.ToLog()`. I'm not sure what would be most idiomatic.