### PR TITLE
feat:  [TB] Set user-agent

### DIFF
--- a/server/RdtClient.Service/BackgroundServices/ProviderUpdater.cs
+++ b/server/RdtClient.Service/BackgroundServices/ProviderUpdater.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using RdtClient.Data.Enums;
 using RdtClient.Service.Services;
 
 namespace RdtClient.Service.BackgroundServices;
@@ -61,13 +60,7 @@ public class ProviderUpdater(ILogger<TaskRunner> logger, IServiceProvider servic
                 logger.LogError(ex, $"Unexpected error occurred in ProviderUpdater: {ex.Message}");
             }
 
-            var delaySeconds = Settings.Get.Provider.Provider switch
-            {
-                Provider.TorBox => 10,
-                _ => 1
-            };
-
-            await Task.Delay(TimeSpan.FromSeconds(delaySeconds), stoppingToken);
+            await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
         }
 
         logger.LogInformation("ProviderUpdater stopped.");

--- a/server/RdtClient.Service/BackgroundServices/ProviderUpdater.cs
+++ b/server/RdtClient.Service/BackgroundServices/ProviderUpdater.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using RdtClient.Data.Enums;
 using RdtClient.Service.Services;
 
 namespace RdtClient.Service.BackgroundServices;
@@ -60,7 +61,13 @@ public class ProviderUpdater(ILogger<TaskRunner> logger, IServiceProvider servic
                 logger.LogError(ex, $"Unexpected error occurred in ProviderUpdater: {ex.Message}");
             }
 
-            await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+            var delaySeconds = Settings.Get.Provider.Provider switch
+            {
+                Provider.TorBox => 10,
+                _ => 1
+            };
+
+            await Task.Delay(TimeSpan.FromSeconds(delaySeconds), stoppingToken);
         }
 
         logger.LogInformation("ProviderUpdater stopped.");

--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -25,6 +25,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
             }
 
             var httpClient = httpClientFactory.CreateClient();
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "rdt-client");
             httpClient.Timeout = TimeSpan.FromSeconds(Settings.Get.Provider.Timeout);
 
             var torBoxNetClient = new TorBoxNetClient(null, httpClient, 5);


### PR DESCRIPTION
TB are experiencing high load from clients which don't set their user agent.
I'm willing to wager that a reasonable chunk of those clients are `rdt-client`.

This PR sets a user-agent so TB can easily tell `rdt-client` apart from other clients.

I've also spoken to them about implementing something similar to AD's "status -live mode", so we could just fetch updates to the list of all torrents rather than getting every single one every single time.