### PR TITLE
Add `dotnet-test` GitHub Action

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1,0 +1,24 @@
+name: dotnet test
+
+on:
+  push:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Restore dependencies
+        run: dotnet restore server
+      - name: Build
+        run: dotnet build --no-restore server
+      - name: Test
+        run: dotnet test --no-build --verbosity normal server


### PR DESCRIPTION
Adds a GitHub Action to run the tests against every push to every branch and every PR to `master`.

I've decided not to cache the nuget packages as I figured <10 seconds of CI time isn't worth caching.

Builds the entire app, not just enough for the tests (which currently only test `RdtClient.Service`.