### PR TITLE
feat: [AD] [RD] don't download anything when all files excluded

### DIFF
--- a/server/RdtClient.Service.Test/Services/TorrentClients/AllDebridTorrentClientTest.cs
+++ b/server/RdtClient.Service.Test/Services/TorrentClients/AllDebridTorrentClientTest.cs
@@ -476,7 +476,7 @@ public class AllDebridTorrentClientTest
     }
 
     [Fact]
-    public async Task GetDownloadLinks_WhenAllFilesExcluded_ReturnsAllFiles()
+    public async Task GetDownloadLinks_WhenAllFilesExcluded_ReturnsEmptyList()
     {
         // Arrange
         var mocks = new Mocks();
@@ -501,8 +501,7 @@ public class AllDebridTorrentClientTest
                 DownloadLink = "https://fake.url/file-2.txt"
             }
         ];
-
-        var expectedLinksSet = new HashSet<String>(files.Select(n => n.DownloadLink)!);
+        
         mocks.AllDebridClientMock.Setup(c => c.Magnet.FilesAsync(Int64.Parse(torrent.RdId), It.IsAny<CancellationToken>())).ReturnsAsync(files);
         mocks.FileFilterMock.Setup(f => f.IsDownloadable(torrent, It.IsAny<String>(), It.IsAny<Int64>())).Returns(false);
 
@@ -513,8 +512,7 @@ public class AllDebridTorrentClientTest
 
         // Assert
         Assert.NotNull(result);
-        var linksSet = new HashSet<String>(result);
-        Assert.Equal(expectedLinksSet, linksSet);
+        Assert.Empty(result);
 
         mocks.FileFilterMock.Verify(f => f.IsDownloadable(torrent, "file-1.txt", 100));
         mocks.FileFilterMock.Verify(f => f.IsDownloadable(torrent, "file-2.txt", 100));

--- a/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
@@ -252,27 +252,13 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IAll
             return null;
         }
 
+        Log($"Getting download links", torrent);
+
         var allFiles = await allDebridNetClientFactory.GetClient().Magnet.FilesAsync(Int64.Parse(torrent.RdId));
 
         var files = GetFiles(allFiles);
 
         files = files.Where(f => fileFilter.IsDownloadable(torrent, f.Path, f.Bytes)).ToList();
-
-        Log($"Getting download links", torrent);
-
-        if (files.Count == 0)
-        {
-            Log($"Filtered all files out! Downloading ALL files instead!", torrent);
-
-            files = GetFiles(allFiles);
-        }
-
-        Log($"Selecting links:");
-
-        foreach (var file in files)
-        {
-            Log($"{file.Path} ({file.Bytes}b) {file.DownloadLink}");
-        }
 
         return files.Where(m => m.DownloadLink != null).Select(m => m.DownloadLink!.ToString()).ToList();
     }

--- a/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
@@ -144,7 +144,7 @@ public class RealDebridTorrentClient(ILogger<RealDebridTorrentClient> logger, IH
 
     public async Task SelectFiles(Data.Models.Data.Torrent torrent)
     {
-        IList<TorrentClientFile> files;
+        List<TorrentClientFile> files;
 
         Log("Seleting files", torrent);
 
@@ -155,31 +155,16 @@ public class RealDebridTorrentClient(ILogger<RealDebridTorrentClient> logger, IH
         }
         else
         {
-            Log("Selecting all files", torrent);
+            Log("Selecting files", torrent);
             files = [.. torrent.Files];
         }
 
-        Log($"Selecting {files.Count}/{torrent.Files.Count} files", torrent);
 
         files = files.Where(f => fileFilter.IsDownloadable(torrent, f.Path, f.Bytes)).ToList();
 
-        if (files.Count == 0)
-        {
-            Log($"Filtered all files out! Downloading ALL files instead!", torrent);
-
-            files = torrent.Files;
-        }
+        Log($"Selecting {files.Count}/{torrent.Files.Count} files", torrent);
 
         var fileIds = files.Select(m => m.Id.ToString()).ToArray();
-
-        Log($"Selecting files:");
-
-        foreach (var file in files)
-        {
-            Log($"{file.Id}: {file.Path} ({file.Bytes}b)");
-        }
-
-        Log("", torrent);
 
         await GetClient().Torrents.SelectFilesAsync(torrent.RdId!, [.. fileIds]);
     }


### PR DESCRIPTION
Brings AD and RD behaviour in line with other `ITorrentClient`s. 

Instead of including all files when all are excluded, the torrent will be put in an error state like the other `ITorrentClient`s.

fixes #757