### PR TITLE
fix: typo - proxyserver setting applies to bezzad not internal

### DIFF
--- a/server/RdtClient.Data/Models/Internal/DbSettings.cs
+++ b/server/RdtClient.Data/Models/Internal/DbSettings.cs
@@ -111,8 +111,8 @@ public class DbSettingsDownloadClient
     [Description("Timeout in milliseconds before the downloader times out.")]
     public Int32 Timeout { get; set; } = 5000;
 
-    [DisplayName("Proxy Server (only used for the Internal Downloader)")]
-    [Description("Address of a proxy server to download through (only used for the Internal Downloader).")]
+    [DisplayName("Proxy Server (only used for the Bezzad Downloader)")]
+    [Description("Address of a proxy server to download through (only used for the Bezzad Downloader).")]
     public String? ProxyServer { get; set; } = null;
 
     [DisplayName("Aria2c URL (only used for the Aria2c Downloader)")]


### PR DESCRIPTION
The only usage of `DbSettingsDownloadClient.ProxyServer` is in `Bezzad` according to my IDE

See also: [GitHub search](https://github.com/search?q=repo%3Arogerfar/rdt-client%20ProxyServer&type=code) for the string `ProxyServer`

Closes #578 