### PR TITLE
fix: require auth to setup provider

### DIFF
--- a/server/RdtClient.Web/Controllers/AuthController.cs
+++ b/server/RdtClient.Web/Controllers/AuthController.cs
@@ -67,7 +67,7 @@ public class AuthController(Authentication authentication, Settings settings) : 
         return Ok();
     }
 
-    [AllowAnonymous]
+    [Authorize(Policy = "AuthSetting")]
     [Route("SetupProvider")]
     [HttpPost]
     public async Task<ActionResult> SetupProvider([FromBody] AuthControllerSetupProviderRequest? request)
@@ -78,13 +78,6 @@ public class AuthController(Authentication authentication, Settings settings) : 
         }
 
         if (!String.IsNullOrEmpty(Settings.Get.Provider.ApiKey))
-        {
-            return StatusCode(401);
-        }
-
-        var user = await authentication.GetUser();
-
-        if (user != null)
         {
             return StatusCode(401);
         }


### PR DESCRIPTION
fixes #743 

In [794eec8](https://github.com/rogerfar/rdt-client/commit/794eec8), the following lines were added to `SetupProvider`

```csharp
var user = await authentication.GetUser();

if (user != null)
{
    return StatusCode(401);
}
```

But in the frontend, setting up the provider is done after creating the user account, so `user != null` 