### PR TITLE
feat: Allow ignoring update notifications (but notify anyway if GHSA found)

### DIFF
--- a/client/src/app/models/profile.model.ts
+++ b/client/src/app/models/profile.model.ts
@@ -4,5 +4,6 @@ export class Profile {
   public expiration: Date;
   public currentVersion: string;
   public latestVersion: string;
+  public isInsecure: boolean;
   public disableUpdateNotification: boolean;
 }

--- a/client/src/app/models/profile.model.ts
+++ b/client/src/app/models/profile.model.ts
@@ -4,4 +4,5 @@ export class Profile {
   public expiration: Date;
   public currentVersion: string;
   public latestVersion: string;
+  public disableUpdateNotification: boolean;
 }

--- a/client/src/app/navbar/navbar.component.html
+++ b/client/src/app/navbar/navbar.component.html
@@ -62,9 +62,15 @@
   </div>
 </nav>
 <div
-  class="notification is-warning"
-  *ngIf="profile && !profile.disableUpdateNotification && profile.latestVersion && profile.currentVersion !== profile.latestVersion"
+  class="notification"
+  [ngClass]="profile.isInsecure ? 'is-danger' : 'is-warning'"
+  *ngIf="profile && (!profile.disableUpdateNotification || profile.isInsecure) && profile.latestVersion && profile.currentVersion !== profile.latestVersion"
 >
-  Version {{ profile.latestVersion }} of RealDebrid Client was found. You are currently on version
-  {{ profile.currentVersion }}.
+  <span *ngIf="profile.isInsecure">
+    Your current version is insecure.
+  </span>
+  <span>
+    Version {{ profile.latestVersion }} of RealDebrid Client was found. You are currently on version
+    {{ profile.currentVersion }}.
+  </span>
 </div>

--- a/client/src/app/navbar/navbar.component.html
+++ b/client/src/app/navbar/navbar.component.html
@@ -63,7 +63,7 @@
 </nav>
 <div
   class="notification is-warning"
-  *ngIf="profile && profile.latestVersion && profile.currentVersion !== profile.latestVersion"
+  *ngIf="profile && !profile.disableUpdateNotification && profile.latestVersion && profile.currentVersion !== profile.latestVersion"
 >
   Version {{ profile.latestVersion }} of RealDebrid Client was found. You are currently on version
   {{ profile.currentVersion }}.

--- a/server/RdtClient.Data/Models/Internal/DbSettings.cs
+++ b/server/RdtClient.Data/Models/Internal/DbSettings.cs
@@ -74,6 +74,10 @@ Supports the following parameters:
     [DisplayName("Copy added torrent files")]
     [Description("When a torrent file or magnet is added, create a copy in this directory.")]
     public String? CopyAddedTorrents { get; set; } = null;
+    
+    [DisplayName("Disable update notifications")]
+    [Description("Ignore update notifications. You will still be notified if the version you are running has a security vulnerability.")]
+    public Boolean DisableUpdateNotifications { get; set; } = false;
 }
 
 public class DbSettingsDownloadClient

--- a/server/RdtClient.Data/Models/Internal/Profile.cs
+++ b/server/RdtClient.Data/Models/Internal/Profile.cs
@@ -7,4 +7,5 @@ public class Profile
     public DateTimeOffset? Expiration { get; set; }
     public String? CurrentVersion { get; set; }
     public String? LatestVersion { get; set; }
+    public Boolean? DisableUpdateNotification { get; set; }
 }

--- a/server/RdtClient.Data/Models/Internal/Profile.cs
+++ b/server/RdtClient.Data/Models/Internal/Profile.cs
@@ -7,5 +7,6 @@ public class Profile
     public DateTimeOffset? Expiration { get; set; }
     public String? CurrentVersion { get; set; }
     public String? LatestVersion { get; set; }
+    public Boolean? IsInsecure { get; set; }
     public Boolean? DisableUpdateNotification { get; set; }
 }

--- a/server/RdtClient.Service/BackgroundServices/UpdateChecker.cs
+++ b/server/RdtClient.Service/BackgroundServices/UpdateChecker.cs
@@ -9,6 +9,11 @@ public class UpdateChecker(ILogger<UpdateChecker> logger) : BackgroundService
 {
     public static String? CurrentVersion { get; private set; }
     public static String? LatestVersion { get; private set; }
+    
+    public static Boolean? IsInsecure { get; private set; }
+
+    private static readonly List<String> KnownGhsaIds = [
+    ];
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -34,18 +39,9 @@ public class UpdateChecker(ILogger<UpdateChecker> logger) : BackgroundService
         {
             try
             {
-                var httpClient = new HttpClient();
-                httpClient.DefaultRequestHeaders.UserAgent.Add(new("RdtClient", CurrentVersion));
-                var response = await httpClient.GetStringAsync($"https://api.github.com/repos/rogerfar/rdt-client/tags?per_page=1", stoppingToken);
+                var gitHubReleases = await GitHubRequest<List<GitHubReleasesResponse>>("/repos/rogerfar/rdt-client/tags?per_page=1", stoppingToken);
 
-                var gitHubReleases = JsonConvert.DeserializeObject<List<GitHubReleasesResponse>>(response);
-
-                if (gitHubReleases == null || gitHubReleases.Count == 0)
-                {
-                    return;
-                }
-
-                var latestRelease = gitHubReleases.FirstOrDefault(m => m.Name != null)?.Name;
+                var latestRelease = gitHubReleases?.FirstOrDefault(m => m.Name != null)?.Name;
 
                 if (latestRelease == null)
                 {
@@ -59,6 +55,18 @@ public class UpdateChecker(ILogger<UpdateChecker> logger) : BackgroundService
                 }
 
                 LatestVersion = latestRelease;
+
+                var gitHubSecurityAdvisories = await GitHubRequest<List<GitHubSecurityAdvisoriesResponse>>("/repos/rogerfar/rdt-client/security-advisories", stoppingToken);
+
+                var unseenGhsaIds = gitHubSecurityAdvisories?.Where(advisory => !KnownGhsaIds.Contains(advisory.GhsaId));
+                
+                if (unseenGhsaIds == null)
+                {
+                    logger.LogWarning($"Unable to find security advisories on GitHub");
+                    return;
+                }
+
+                IsInsecure = unseenGhsaIds.Any();
             }
             catch (Exception ex)
             {
@@ -70,10 +78,25 @@ public class UpdateChecker(ILogger<UpdateChecker> logger) : BackgroundService
 
         logger.LogInformation("UpdateChecker stopped.");
     }
+
+    private async Task<T?> GitHubRequest<T>(String endpoint, CancellationToken cancellationToken)
+    {
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new("RdtClient", CurrentVersion));
+            var response = await httpClient.GetStringAsync($"https://api.github.com{endpoint}", cancellationToken);
+            
+            return JsonConvert.DeserializeObject<T>(response);
+    }
 }
 
 public class GitHubReleasesResponse 
 {
     [JsonProperty("name")]
     public String? Name { get; set; }
+}
+
+public class GitHubSecurityAdvisoriesResponse
+{
+    [JsonProperty("ghsa_id")]
+    public required String GhsaId { get; set; } 
 }

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -414,6 +414,7 @@ public class Torrents(
             Expiration = user.Expiration,
             CurrentVersion = UpdateChecker.CurrentVersion,
             LatestVersion = UpdateChecker.LatestVersion,
+            IsInsecure = UpdateChecker.IsInsecure,
             DisableUpdateNotification = Settings.Get.General.DisableUpdateNotifications
         };
 

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -413,7 +413,8 @@ public class Torrents(
             UserName = user.Username,
             Expiration = user.Expiration,
             CurrentVersion = UpdateChecker.CurrentVersion,
-            LatestVersion = UpdateChecker.LatestVersion
+            LatestVersion = UpdateChecker.LatestVersion,
+            DisableUpdateNotification = Settings.Get.General.DisableUpdateNotifications
         };
 
         return profile;


### PR DESCRIPTION
Closes #552 

Adds a setting (under General) `DisableUpdateNotifications` (default `false`). When true, we won't show update notifications to users.

I also added some stuff to check if there have been any GitHub Security Advisories published. This is done by checking the list of published security advisories in `rogerfar/rdt-client` against a list of known fixed GHSA IDs. I'm pretty sure these IDs  are immutable. I figured given we expect to have very few reported vulnerabilities, hard-coding them won't be too bad. There's no official standard for how the version numbers should be done, so parsing the vulnerable version number with a regex or string manipulation may not work.

This is only really relevant if we want to use GHSAs to report vulnerabilities to our users. So I can revert the second commit upon request.
If we *do* decide to go with GHSAs, an advisory for the `/Authentication/Update` endpoint vulnerability should probably be made and the ID added  to the list in `UpdateChecker`