### PR TITLE
[TB] use `torrentClientTorrent` (if passed) instead of re-fetching in `UpdateData`

### DIFF
--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -206,7 +206,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
                 return torrent;
             }
 
-            var rdTorrent = await GetInfo(torrent.Hash) ?? throw new($"Resource not found");
+            var rdTorrent = torrentClientTorrent ?? await GetInfo(torrent.Hash) ?? throw new($"Resource not found");
 
             if (!String.IsNullOrWhiteSpace(rdTorrent.Filename))
             {


### PR DESCRIPTION
Currently, even when `torrentClientTorrent` is not `null`, `TorBoxTorrentClient.UpdateData(torrent, torrentClientTorrent)` does not use the second argument and instead fetches from `TB`.

This results in `n + 1` calls to `/mylist` and up to `n + 1` calls to `/getqueued` every time `ProviderUpdater` runs (where `n` is the number of torrents in TB which have been added to `rdt-client` - that is, the number of torrents in `rdt-client` which haven't been deleted from TB).

##### These changes only affect behaviour in `ProviderUpdater` runs:
`ITorrentClient.UpdateData` is used only by the private method `Torrents.UpdateTorrentClientData`. That method is only called with `torrentClientTorrent` in 2 places, both in `Torrents.UpdateRdData`, which is called only by `ProviderUpdater`.
So `torrentClientTorrent` is always null unless it's called because of a `ProviderUpdater` run, and this PR won't change any behaviour outside of `ProviderUpdater` runs.
<details><summary>Code Snippets of usages</summary>
<p>

Only usage of `ITorrentClient.UpdateData`
https://github.com/rogerfar/rdt-client/blob/aa6e6c7df539637dbf70a66caa43abf1d4e418ac/server/RdtClient.Service/Services/Torrents.cs#L809-L815

Context for snippet below:
https://github.com/rogerfar/rdt-client/blob/aa6e6c7df539637dbf70a66caa43abf1d4e418ac/server/RdtClient.Service/Services/Torrents.cs#L422-L437
Only 2 usages of `UpdateTorrentClientData` with 2 args:
https://github.com/rogerfar/rdt-client/blob/aa6e6c7df539637dbf70a66caa43abf1d4e418ac/server/RdtClient.Service/Services/Torrents.cs#L463-L467
</p>
</details> 

---

@asylumexp can you take a look at this? I'd ask for a review via the proper UI but it won't let me until you comment (I think).

Related: #738 