### PR TITLE
`ProviderUpdater`: don't run if all torrents finished and `AutoImport == false`

### DIFF
--- a/server/RdtClient.Service/BackgroundServices/ProviderUpdater.cs
+++ b/server/RdtClient.Service/BackgroundServices/ProviderUpdater.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using RdtClient.Data.Enums;
 using RdtClient.Service.Services;
 
 namespace RdtClient.Service.BackgroundServices;
@@ -26,8 +27,8 @@ public class ProviderUpdater(ILogger<TaskRunner> logger, IServiceProvider servic
             try
             {
                 var torrents = await torrentService.Get();
-                
-                if (_nextUpdate < DateTime.UtcNow && ((torrents.Count > 0 && !Settings.Get.Provider.AutoImport) || Settings.Get.Provider.AutoImport))
+
+                if (_nextUpdate < DateTime.UtcNow && (Settings.Get.Provider.AutoImport || torrents.Any(t => t.RdStatus != TorrentStatus.Finished)))
                 {
                     logger.LogDebug($"Updating torrent info from debrid provider");
                     


### PR DESCRIPTION
Currently the `ProviderUpdater` runs even when all torrents are finished.
Presumably if all torrents are finished on the debrid provider, we no longer care about updates to its status. 
We know it's either
-  not there
  which could be useful information for the symlink downloader, but afaik isn't used as such
- the same as before
  so we won't need to change anything in the database

In a working sonarr/radarr + rdt-client setup, no torrents should be left lying around on `Finished`. But in practice, this sometimes happens, especially if users have misconfigured. My personal motivation for this is for the container I use for testing which often has finished downloads sitting around, but I've periodically found my main instance with torrents left on `Finished` because sonarr/radarr has rejected them for various reasons.

---

I might have a misconception here though - *is* there  utility in updating torrents with `RdStatus === Finished`?