### PR TITLE
add `word-break: break-all` to torrent name `td`

### DIFF
--- a/client/src/app/torrent-table/torrent-table.component.html
+++ b/client/src/app/torrent-table/torrent-table.component.html
@@ -33,7 +33,7 @@
             [checked]="selectedTorrents.contains(torrent.torrentId)"
           />
         </td>
-        <td (click)="openTorrent(torrent.torrentId)">
+        <td (click)="openTorrent(torrent.torrentId)" class="break-all">
           {{ torrent.rdName }}
         </td>
         <td>

--- a/client/src/app/torrent-table/torrent-table.component.scss
+++ b/client/src/app/torrent-table/torrent-table.component.scss
@@ -1,6 +1,9 @@
 table {
   tr {
     cursor: pointer;
+    td.break-all {
+      word-break: break-all;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #758

Long words in torrents' `rdName`s causes a very wide table and a horizontal scroll bar to appear.
By letting the torrent names bee broken across multiple lines, they can be basically any width, so don't cause the torrent table to exceed its container.

Before: 
<img width="1373" src="https://github.com/user-attachments/assets/684624c3-c75f-4919-9ed0-633438370eb1" />
After:
<img width="1378" src="https://github.com/user-attachments/assets/4652e45a-3ca4-4e78-8933-1e6447880eb9" />


