### PR TITLE
feat: add setting to change RD api hostname

### DIFF
--- a/server/RdtClient.Data/Models/Internal/DbSettings.cs
+++ b/server/RdtClient.Data/Models/Internal/DbSettings.cs
@@ -181,6 +181,13 @@ or
 <a href=""https://debrid-link.com/webapp/apikey"" target=""_blank"" rel=""noopener"">https://debrid-link.com/webapp/apikey</a>")]
     public String ApiKey { get; set; } = "";
 
+    /// <summary>
+    /// API hostname to use <b>for Real Debrid only</b> 
+    /// </summary>
+    [DisplayName("API Hostname (RD only)")]
+    [Description("Use this instead of the normal hostname for Real Debrid API requests. Only used by Real Debrid. Leave blank to use default.")]
+    public String? ApiHostname { get; set; }
+
     [DisplayName("Automatically import and process torrents added to provider")]
     [Description("When selected, import downloads that are not added through RealDebridClient but have been directly added to your debrid provider.")]
     public Boolean AutoImport { get; set; } = false;

--- a/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
@@ -26,7 +26,7 @@ public class RealDebridTorrentClient(ILogger<RealDebridTorrentClient> logger, IH
             var httpClient = httpClientFactory.CreateClient(DiConfig.RD_CLIENT);
             httpClient.Timeout = TimeSpan.FromSeconds(Settings.Get.Provider.Timeout);
 
-            var rdtNetClient = new RdNetClient(null, httpClient, 5);
+            var rdtNetClient = new RdNetClient(null, httpClient, 5, Settings.Get.Provider.ApiHostname);
             rdtNetClient.UseApiAuthentication(apiKey);
 
             // Get the server time to fix up the timezones on results


### PR DESCRIPTION
Closes #727

As RD's main api hostname (`api.real-debrid.com`) is blocked by some(?) Turkish ISPs, letting users use alternative/unblocked hostnames (`api-1.real-debrid.com` etc.) allows them to still use `rdt-client` despite the block.