### PR TITLE
fix: return number of files selected from `SelectFiles` so we can handle all files excluded for RD

### DIFF
--- a/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
@@ -155,9 +155,10 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IAll
         return Task.FromResult<IList<TorrentClientAvailableFile>>([]);
     }
 
-    public Task SelectFiles(Torrent torrent)
+    /// <inheritdoc />
+    public Task<Int32?> SelectFiles(Torrent torrent)
     {
-        return Task.CompletedTask;
+        return Task.FromResult<Int32?>(torrent.Files.Count);
     }
 
     public async Task Delete(String torrentId)

--- a/server/RdtClient.Service/Services/TorrentClients/DebridLinkTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/DebridLinkTorrentClient.cs
@@ -136,9 +136,10 @@ public class DebridLinkClient(ILogger<DebridLinkClient> logger, IHttpClientFacto
         return Task.FromResult<IList<TorrentClientAvailableFile>>([]);
     }
 
-    public Task SelectFiles(Data.Models.Data.Torrent torrent)
+    /// <inheritdoc />
+    public Task<Int32?> SelectFiles(Data.Models.Data.Torrent torrent)
     {
-        return Task.CompletedTask;
+        return Task.FromResult<Int32?>(torrent.Files.Count);
     }
 
     public async Task Delete(String torrentId)

--- a/server/RdtClient.Service/Services/TorrentClients/ITorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/ITorrentClient.cs
@@ -10,7 +10,15 @@ public interface ITorrentClient
     Task<String> AddMagnet(String magnetLink);
     Task<String> AddFile(Byte[] bytes);
     Task<IList<TorrentClientAvailableFile>> GetAvailableFiles(String hash);
-    Task SelectFiles(Torrent torrent);
+    /// <summary>
+    /// Tell the debrid provider which files to download.
+    /// </summary>
+    /// <remark>
+    /// Not all providers support this feature.
+    /// </remark>
+    /// <param name="torrent">The torrent to select files for</param>
+    /// <returns>Number of files selected</returns>
+    Task<Int32?> SelectFiles(Torrent torrent);
     Task Delete(String torrentId);
     Task<String> Unrestrict(String link);
     Task<Torrent> UpdateData(Torrent torrent, TorrentClientTorrent? torrentClientTorrent);

--- a/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
@@ -121,9 +121,12 @@ public class PremiumizeTorrentClient(ILogger<PremiumizeTorrentClient> logger, IH
         return Task.FromResult<IList<TorrentClientAvailableFile>>([]);
     }
 
-    public Task SelectFiles(Torrent torrent)
+    /// <inheritdoc />
+    public Task<Int32?> SelectFiles(Torrent torrent)
     {
-        return Task.CompletedTask;
+        // torrent.Files is not populated when this function is called
+        // by returning 1, we ensure no logic for "all files excluded" is followed
+        return Task.FromResult<Int32?>(1);
     }
 
     public async Task Delete(String id)

--- a/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/RealDebridTorrentClient.cs
@@ -142,7 +142,8 @@ public class RealDebridTorrentClient(ILogger<RealDebridTorrentClient> logger, IH
         return Task.FromResult<IList<TorrentClientAvailableFile>>([]);
     }
 
-    public async Task SelectFiles(Data.Models.Data.Torrent torrent)
+    /// <inheritdoc />
+    public async Task<Int32?> SelectFiles(Data.Models.Data.Torrent torrent)
     {
         List<TorrentClientFile> files;
 
@@ -166,7 +167,14 @@ public class RealDebridTorrentClient(ILogger<RealDebridTorrentClient> logger, IH
 
         var fileIds = files.Select(m => m.Id.ToString()).ToArray();
 
+        if (fileIds.Length == 0)
+        {
+            return 0;
+        }
+
         await GetClient().Torrents.SelectFilesAsync(torrent.RdId!, [.. fileIds]);
+
+        return fileIds.Length;
     }
 
     public async Task Delete(String torrentId)

--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -171,9 +171,10 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
         return [];
     }
 
-    public Task SelectFiles(Torrent torrent)
+    /// <inheritdoc />
+    public Task<Int32?> SelectFiles(Torrent torrent)
     {
-        return Task.CompletedTask;
+        return Task.FromResult<Int32?>(torrent.Files.Count);
     }
 
     public async Task Delete(String torrentId)


### PR DESCRIPTION
In #741 RD and AD were brought in line with other providers and don't download anything when all files are excluded.

But for RD, the error message isn't great - `Missing Parameter` is all that is shown to the user. This is an error from RD's API complaining because we didn't specify any `fileId`s.

Initially, I just threw an error in `RealDebridTorrentClient.SelectFiles` when `fileIds.Length == 0`. But that felt wrong - it's not really exceptional behaviour, and only works because of how we catch errors when calling this function.
Instead, I've decided to return the number of files selected, and if none are selected, call `MarkAllFilesExcluded` to put the torrent into the same error state as all the other providers would.
The second solution feels more elegant to me, but I'll happily close this and open another PR with my initial solution if it's preferred.

closes #757