### PR TITLE
fix: [PM] `GetDownloadLinks`: return empty list not null when all files excluded

### DIFF
--- a/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
@@ -228,13 +228,6 @@ public class PremiumizeTorrentClient(ILogger<PremiumizeTorrentClient> logger, IH
             downloadLinks.Add(file.Link);
         }
 
-        if (downloadLinks.Count == 0)
-        {
-            Log($"No download links found for transfer {transfer.Name} ({transfer.Id})", torrent);
-
-            return null;
-        }
-
         foreach (var link in downloadLinks)
         {
             Log($"Found {link}", torrent);


### PR DESCRIPTION
Fixes #771

For context, the code below is the only place `GetDownloadLinks` is called
https://github.com/rogerfar/rdt-client/blob/a660a86bb4606541f53e1879962ca4f51171f0e0/server/RdtClient.Service/Services/Torrents.cs#L238-L257

By returning `null` from `PremiumizeTorrentClient.GetDownloadLinks` when all files have been excluded, we take the wrong path through the code above.

<details><summary>Log excerpt from after this PR</summary>
<p>

```
[13:34:29 DBG] Add file
[13:34:29 DBG] bytes System.Byte[]
[13:34:29 DBG] Updating torrent info from debrid provider
[13:34:29 DBG] Adding A0BF6E90BCF31DB5635CD9F2158B76955FB91A40 torrent file for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
[13:34:29 DBG] Method: GET, Path: /Api/Torrents
[13:34:29 DBG] Finished updating torrent info from debrid provider, next update in 10 seconds
[13:34:30 DBG] Processing 1 torrents
[13:34:30 DBG] Currently 0 queued downloads and 0 total active downloads for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
[13:34:30 DBG] Processing for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
[13:34:30 DBG] Selecting files for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
[13:34:31 DBG] Processing 1 torrents
[13:34:31 DBG] Currently 0 queued downloads and 0 total active downloads for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
[13:34:31 DBG] Processing for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
[13:34:31 DBG] Creating downloads for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
[13:34:31 DBG] Found 5 transfers for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
[13:34:31 DBG] Found transfer TestMultiple (mY-3fR2N421Q_tjDgcfRIw) for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
[13:34:31 DBG] Found 2 items in folder TestMultiple (QaCoaMhPuyjjT8xB_0pLpw) for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
[13:34:31 DBG] Not downloading file TestMultiple.txt matches regex [Tt]est
[13:34:31 DBG] Not downloading file TestMultiple2.txt matches regex [Tt]est
[13:34:31 INF] All files excluded by filters (IncludeRegex: null, ExcludeRegex: [Tt]est, DownloadMinSize: 0  for torrent TestMultiple (mY-3fR2N421Q_tjDgcfRIw - finished 100%) (d54ef891-bd12-4b0b-82dd-2a876f0b1cfb)
```

</p>
</details> 

<details><summary>Log excerpt from before this PR</summary>
<p>

Paragraphs are done by me.
```
[13:35:00 DBG] Adding A0BF6E90BCF31DB5635CD9F2158B76955FB91A40 torrent file for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:00 DBG] Processing 1 torrents
[13:35:00 DBG] Currently 0 queued downloads and 0 total active downloads for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:00 DBG] Processing for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:00 DBG] Selecting files for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)

[13:35:01 DBG] Processing 1 torrents
[13:35:01 DBG] Currently 0 queued downloads and 0 total active downloads for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:01 DBG] Processing for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:01 DBG] Creating downloads for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:01 DBG] Found 5 transfers for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:01 DBG] Found transfer TestMultiple (RwBiAc29gwVMe396e9Je0A) for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:01 DBG] Found 2 items in folder TestMultiple (RJ_oJ4K3AwAqYoGVNGFxbA) for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:01 DBG] Not downloading file TestMultiple.txt matches regex [Tt]est
[13:35:01 DBG] Not downloading file TestMultiple2.txt matches regex [Tt]est
[13:35:01 DBG] No download links found for transfer TestMultiple (RwBiAc29gwVMe396e9Je0A) for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)

[13:35:02 DBG] Processing 1 torrents
[13:35:02 DBG] Currently 0 queued downloads and 0 total active downloads for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:02 DBG] Processing for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:02 DBG] Creating downloads for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:03 DBG] Found 5 transfers for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:03 DBG] Found transfer TestMultiple (RwBiAc29gwVMe396e9Je0A) for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:03 DBG] Found 2 items in folder TestMultiple (RJ_oJ4K3AwAqYoGVNGFxbA) for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:03 DBG] Not downloading file TestMultiple.txt matches regex [Tt]est
[13:35:03 DBG] Not downloading file TestMultiple2.txt matches regex [Tt]est
[13:35:03 DBG] No download links found for transfer TestMultiple (RwBiAc29gwVMe396e9Je0A) for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)

[13:35:04 DBG] Processing 1 torrents
[13:35:04 DBG] Currently 0 queued downloads and 0 total active downloads for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:04 DBG] Processing for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:04 DBG] Creating downloads for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:04 DBG] Found 5 transfers for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:04 DBG] Found transfer TestMultiple (RwBiAc29gwVMe396e9Je0A) for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:04 DBG] Found 2 items in folder TestMultiple (RJ_oJ4K3AwAqYoGVNGFxbA) for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)
[13:35:04 DBG] Not downloading file TestMultiple.txt matches regex [Tt]est
[13:35:04 DBG] Not downloading file TestMultiple2.txt matches regex [Tt]est
[13:35:04 DBG] No download links found for transfer TestMultiple (RwBiAc29gwVMe396e9Je0A) for torrent TestMultiple (RwBiAc29gwVMe396e9Je0A - finished 100%) (06be7535-66ec-482a-b294-afab9051f604)

...repeats...
```

</p>
</details> 