### PR TITLE
Debrid Queue fixes (don't auto delete queued torrents, handle errors when dequeueing)

### DIFF
--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -333,7 +333,15 @@ public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Dow
 
             foreach (var torrent in torrentsToAddToProvider.Take(dequeueCount))
             {
-                await torrents.DequeueFromDebridQueue(torrent);
+                try
+                {
+                    await torrents.DequeueFromDebridQueue(torrent);
+                }
+                catch (Exception ex)
+                {
+                    await torrents.UpdateComplete(torrent.TorrentId, $"Could not add to provider: {ex.Message}", DateTimeOffset.Now, true);
+                    logger.LogWarning(ex, "Could not dequeue torrent {torrentId}", torrent.TorrentId);
+                }
             }
         }
 

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -523,7 +523,7 @@ public class Torrents(
             {
                 var rdTorrent = rdTorrents.FirstOrDefault(m => m.Id == torrent.RdId);
 
-                if (rdTorrent == null && Settings.Get.Provider.AutoDelete)
+                if (rdTorrent == null && Settings.Get.Provider.AutoDelete && torrent.RdStatus != TorrentStatus.Queued)
                 {
                     await Delete(torrent.TorrentId, true, false, true);
                 }


### PR DESCRIPTION
Potentially fix&ZeroWidthSpace;es #790 
As much as is feasible, fixes #793 
Fixes #797 

I introduced a few bugs with #763 

1. the `AutoDelete` functionality will delete queued torrents, since they won't be found on the provider (they won't have been added yet)
2. if adding the torrent to the provider fails, the error won't be caught, the torrent won't be retried, and no error will be shown to the user