### PR TITLE
fix: Set `HostDownloadAction` when auto-importing torrents

### DIFF
--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -492,6 +492,7 @@ public class Torrents(
                         Category = Settings.Get.Provider.Default.Category,
                         DownloadClient = Settings.Get.DownloadClient.Client,
                         DownloadAction = Settings.Get.Provider.Default.OnlyDownloadAvailableFiles ? TorrentDownloadAction.DownloadAvailableFiles : TorrentDownloadAction.DownloadAll,
+                        HostDownloadAction = Settings.Get.Provider.Default.HostDownloadAction,
                         FinishedAction = Settings.Get.Provider.Default.FinishedAction,
                         DownloadMinSize = Settings.Get.Provider.Default.MinFileSize,
                         IncludeRegex = Settings.Get.Provider.Default.IncludeRegex,


### PR DESCRIPTION
fixes #597

When auto-importing, we never set the `HostDownloadAction`. This (understandably) confused users, given it was a setting they could set.

[GitHub Code Search](https://github.com/search?q=repo%3Arogerfar%2Frdt-client%20Settings.Get.Provider.Default.HostDownloadAction&type=code) for `Settings.Get.Provider.Default.HostDownloadAction`