### PR TITLE
Magnet handler registration contextual links

### DIFF
--- a/client/src/app/settings/settings.component.html
+++ b/client/src/app/settings/settings.component.html
@@ -144,22 +144,36 @@
 <div class="field" *ngIf="activeTab === 0">
   <label class="label">Register client as magnet link handler</label>
   <div class="control">
-    <button 
-      class="button is-info" 
-      type="button" 
-      (click)="registerMagnetHandler()" 
-      [disabled]="!canRegisterMagnetHandler">
+    <button
+      class="button is-info"
+      type="button"
+      (click)="registerMagnetHandler()"
+      [disabled]="!canRegisterMagnetHandler"
+    >
       <span>
-        {{ canRegisterMagnetHandler ? 'Register Handler' : 'Unavailable in This Browser' }}
+        {{ canRegisterMagnetHandler ? "Register Handler" : "Unavailable in This Browser" }}
       </span>
     </button>
   </div>
   <p class="help">
-    {{
-      canRegisterMagnetHandler
-        ? "This will attempt to register the client as your browser's default handler for magnet links and automatically open them in the new torrent screen for downloading."
-        : "Magnet link registration is unavailable because either your browser does not support it or the client is not being served to you in a secure context."
-    }}
+    @if (canRegisterMagnetHandler) {
+      This will attempt to register the client as your browser's default handler for magnet links and automatically open
+      them in the new torrent screen for downloading.
+    } @else {
+      Magnet link registration is unavailable. Your
+      <a href="https://caniuse.com/mdn-api_navigator_registerprotocolhandler" target="_blank" rel="noopener noreferrer">
+        browser may not support this feature
+      </a>
+      , or the client is not being served in a
+      <a
+        href="https://developer.mozilla.org/en-US/docs/Glossary/Secure_Context/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        secure context
+      </a>
+      .
+    }
   </p>
 </div>
 

--- a/client/src/app/settings/settings.component.ts
+++ b/client/src/app/settings/settings.component.ts
@@ -145,10 +145,10 @@ export class SettingsComponent implements OnInit {
 
   public registerMagnetHandler(): void {
     try {
-      navigator.registerProtocolHandler("magnet", `${window.location.origin}/add?magnet=%s`);
-      alert("Success! Your browser will now prompt you to confirm and add the client as the default handler for magnet links.");
+      navigator.registerProtocolHandler('magnet', `${window.location.origin}/add?magnet=%s`);
+      alert('Success! Your browser will now prompt you to confirm and add the client as the default handler for magnet links.');
     } catch (error) {
-      alert("Magnet link registration failed.");
+      alert('Magnet link registration failed.');
     }
   }
 }


### PR DESCRIPTION
Replaced the static help text displayed for magnet handler registration with contextual links.

- [CanIUse.com entry for navigator.registerProtocolHandler](https://caniuse.com/mdn-api_navigator_registerprotocolhandler)
- [MDN glossary on secure contexts](https://developer.mozilla.org/en-US/docs/Glossary/Secure_Context/)