### PR TITLE
Don't unpack if `UnpackLimit` is set to `0`

### DIFF
--- a/server/RdtClient.Data/Models/Internal/DbSettings.cs
+++ b/server/RdtClient.Data/Models/Internal/DbSettings.cs
@@ -43,7 +43,7 @@ public class DbSettingsGeneral
     public Int32 DownloadLimit { get; set; } = 2;
 
     [DisplayName("Maximum unpack processes")]
-    [Description("Maximum amount of downloads that get unpacked on your host at the same time.")]
+    [Description("Maximum amount of downloads that get unpacked on your host at the same time. Set to 0 to disable unpacking.")]
     public Int32 UnpackLimit { get; set; } = 1;
 
     [DisplayName("Categories")]

--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -81,10 +81,6 @@ public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Dow
         }
 
         var settingUnpackLimit = Settings.Get.General.UnpackLimit;
-        if (settingUnpackLimit < 1)
-        {
-            settingUnpackLimit = 1;
-        }
 
         var settingDownloadPath = Settings.Get.DownloadClient.DownloadPath;
         if (String.IsNullOrWhiteSpace(settingDownloadPath))
@@ -485,7 +481,8 @@ public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Dow
                     var extension = Path.GetExtension(download.FileName);
 
                     if ((extension != ".rar" && extension != ".zip") ||
-                        torrent.DownloadClient == Data.Enums.DownloadClient.Symlink)
+                        torrent.DownloadClient == Data.Enums.DownloadClient.Symlink ||
+                        settingUnpackLimit == 0)
                     {
                         Log($"No need to unpack, setting it as unpacked", download, torrent);
 

--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -81,6 +81,10 @@ public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Dow
         }
 
         var settingUnpackLimit = Settings.Get.General.UnpackLimit;
+        if (settingUnpackLimit < 0)
+        {
+            settingUnpackLimit = 0;
+        }
 
         var settingDownloadPath = Settings.Get.DownloadClient.DownloadPath;
         if (String.IsNullOrWhiteSpace(settingDownloadPath))


### PR DESCRIPTION
### **User description**
Fixes #218


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Added ability to disable auto unpacking by setting `UnpackLimit` to 0.

- Updated setting description to clarify disabling behavior.

- Modified unpacking logic to skip when `UnpackLimit` is 0.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DbSettings.cs</strong><dd><code>Clarify UnpackLimit setting disables unpacking at 0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/RdtClient.Data/Models/Internal/DbSettings.cs

<li>Updated the description for <code>UnpackLimit</code> to clarify that setting it to <br>0 disables unpacking.


</details>


  </td>
  <td><a href="https://github.com/rogerfar/rdt-client/pull/817/files#diff-23a4c4267bedcc4df5463507d3a4b453914d73c5d8bc3db93c2305387c570f43">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TorrentRunner.cs</strong><dd><code>Support disabling unpacking when UnpackLimit is 0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/RdtClient.Service/Services/TorrentRunner.cs

<li>Removed forced minimum of 1 for <code>UnpackLimit</code>.<br> <li> Updated unpacking logic to skip unpacking if <code>UnpackLimit</code> is 0.


</details>


  </td>
  <td><a href="https://github.com/rogerfar/rdt-client/pull/817/files#diff-e7ee0a5e208e7ef04cda87a5a111b9199ac93333e36250d6d66a9cfc37e1b8cd">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>