### PR TITLE
set user agent for all `HttpClient`s from `IHttpClientFactory`

### DIFF
--- a/server/RdtClient.Service/DiConfig.cs
+++ b/server/RdtClient.Service/DiConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO.Abstractions;
 using System.Net;
+using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Polly;
@@ -15,6 +16,7 @@ namespace RdtClient.Service;
 public static class DiConfig
 {
     public const String RD_CLIENT = "RdClient";
+    public static readonly String UserAgent = $"rdt-client {Assembly.GetEntryAssembly()?.GetName().Version}";
 
     public static void RegisterRdtServices(this IServiceCollection services)
     {
@@ -55,12 +57,19 @@ public static class DiConfig
 
     public static void RegisterHttpClients(this IServiceCollection services)
     {
-        services.AddHttpClient();
-
         var retryPolicy = HttpPolicyExtensions
                           .HandleTransientHttpError()
                           .OrResult(r => r.StatusCode == HttpStatusCode.TooManyRequests)
                           .WaitAndRetryAsync(retryCount: 5, sleepDurationProvider: attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)));
+
+        services.AddHttpClient();
+        services.ConfigureHttpClientDefaults(builder =>
+        {
+            builder.ConfigureHttpClient(httpClient =>
+            {
+                httpClient.DefaultRequestHeaders.Add("User-Agent", UserAgent);
+            });
+        });
 
         services.AddHttpClient(RD_CLIENT)
                 .AddPolicyHandler(retryPolicy);

--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -24,8 +23,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
                 throw new("TorBox API Key not set in the settings");
             }
 
-            var httpClient = httpClientFactory.CreateClient();
-            httpClient.DefaultRequestHeaders.Add("User-Agent", $"rdt-client {Assembly.GetEntryAssembly()?.GetName().Version}");
+            var httpClient = httpClientFactory.CreateClient(); 
             httpClient.Timeout = TimeSpan.FromSeconds(Settings.Get.Provider.Timeout);
 
             var torBoxNetClient = new TorBoxNetClient(null, httpClient, 5);


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
• Centralized user agent configuration for all HTTP clients
• Removed duplicate user agent setting in TorBoxTorrentClient
• Added global HTTP client defaults configuration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DiConfig.cs</strong><dd><code>Add global HTTP client user agent configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/RdtClient.Service/DiConfig.cs

• Added static UserAgent property with application version<br> • <br>Configured global HTTP client defaults to set user agent<br> • Added <br>System.Reflection import for assembly version access


</details>


  </td>
  <td><a href="https://github.com/rogerfar/rdt-client/pull/842/files#diff-78c3986abf7d0ad947324b9bd1ef7daa9511536766bd164f91ed26ce385c575c">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TorBoxTorrentClient.cs</strong><dd><code>Remove duplicate user agent configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs

• Removed System.Reflection import<br> • Removed manual user agent header <br>setting


</details>


  </td>
  <td><a href="https://github.com/rogerfar/rdt-client/pull/842/files#diff-42024651e027aaf41f60fc093268b98ba1fa9b18461d1ac35a196e4776908ba0">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>