### PR TITLE
Add rate limiting that respect retry-after and TorBox specific limits

### DIFF
--- a/server/RdtClient.Service/DiConfig.cs
+++ b/server/RdtClient.Service/DiConfig.cs
@@ -1,10 +1,16 @@
 ﻿using System.IO.Abstractions;
 using System.Net;
 using System.Reflection;
+using System.Threading.RateLimiting;
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+
 using Polly;
-using Polly.Extensions.Http;
+using Polly.Retry;
+using Polly.RateLimiting;
+
 using RdtClient.Service.BackgroundServices;
 using RdtClient.Service.Middleware;
 using RdtClient.Service.Services;
@@ -16,7 +22,42 @@ namespace RdtClient.Service;
 public static class DiConfig
 {
     public const String RD_CLIENT = "RdClient";
+    public const String TORBOX_CLIENT = "TorboxClient";
+    public const String TORBOX_CLIENT_CREATETORRENT = "TorboxClientCreateTorrent";
     public static readonly String UserAgent = $"rdt-client {Assembly.GetEntryAssembly()?.GetName().Version}";
+
+    private static readonly SlidingWindowRateLimiter TorboxPerSecondLimiter =
+        new(new SlidingWindowRateLimiterOptions
+        {
+            PermitLimit = 5,
+            Window = TimeSpan.FromSeconds(1),
+            SegmentsPerWindow = 4,
+            QueueLimit = 5,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            AutoReplenishment = true
+        });
+
+    private static readonly SlidingWindowRateLimiter TorboxCreateTorrentPerMinuteLimiter =
+        new(new SlidingWindowRateLimiterOptions
+        {
+            PermitLimit = 10,
+            Window = TimeSpan.FromMinutes(1),
+            SegmentsPerWindow = 4,
+            QueueLimit = 5,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            AutoReplenishment = true
+        });
+
+    private static readonly SlidingWindowRateLimiter TorboxCreateTorrentPerHourLimiter =
+        new(new SlidingWindowRateLimiterOptions
+        {
+            PermitLimit = 60,
+            Window = TimeSpan.FromHours(1),
+            SegmentsPerWindow = 60,
+            QueueLimit = 5,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            AutoReplenishment = true
+        });
 
     public static void RegisterRdtServices(this IServiceCollection services)
     {
@@ -57,21 +98,103 @@ public static class DiConfig
 
     public static void RegisterHttpClients(this IServiceCollection services)
     {
-        var retryPolicy = HttpPolicyExtensions
-                          .HandleTransientHttpError()
-                          .OrResult(r => r.StatusCode == HttpStatusCode.TooManyRequests)
-                          .WaitAndRetryAsync(retryCount: 5, sleepDurationProvider: attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)));
-
-        services.AddHttpClient();
-        services.ConfigureHttpClientDefaults(builder =>
+        var retryStrategy = new RetryStrategyOptions<HttpResponseMessage>
         {
-            builder.ConfigureHttpClient(httpClient =>
+            // Transient failures to handle (network errors, 5xx, 408, 429)
+            ShouldHandle = static args =>
             {
-                httpClient.DefaultRequestHeaders.Add("User-Agent", UserAgent);
-            });
+                if (args.Outcome.Exception is HttpRequestException)
+                {
+                    return ValueTask.FromResult(true);
+                }
+
+                if (args.Outcome.Result is HttpResponseMessage r &&
+                    (((int)r.StatusCode >= 500) ||
+                    r.StatusCode == HttpStatusCode.RequestTimeout ||
+                    r.StatusCode == HttpStatusCode.TooManyRequests))
+                {
+                    return ValueTask.FromResult(true);
+                }
+
+                return ValueTask.FromResult(false);
+            },
+
+            // Default backoff when Retry-After is not provided
+            MaxRetryAttempts = 5,
+            Delay = TimeSpan.FromSeconds(1),
+            BackoffType = DelayBackoffType.Exponential,
+            UseJitter = true,
+
+            // Prefer server-provided delay; otherwise use the internal backoff
+            DelayGenerator = static args =>
+            {
+                if (args.Outcome.Result is HttpResponseMessage resp && resp.Headers.RetryAfter is { } ra)
+                {
+                    if (ra.Delta is TimeSpan delta)
+                    {
+                        return new ValueTask<TimeSpan?>(delta);
+                    }
+
+                    if (ra.Date is DateTimeOffset when)
+                    {
+                        var delay = when - DateTimeOffset.UtcNow;
+                        return new ValueTask<TimeSpan?>(delay > TimeSpan.Zero ? delay : TimeSpan.Zero);
+                    }
+                }
+
+                // null => use the configured backoff (Delay/BackoffType/UseJitter)
+                return new ValueTask<TimeSpan?>((TimeSpan?)null);
+            }
+        };
+
+        services.AddHttpClient(RD_CLIENT, httpClient =>
+        {
+            httpClient.DefaultRequestHeaders.Add("User-Agent", UserAgent);
+        })
+        .AddResilienceHandler("DefaultRetryPolicy", builder =>
+        {
+            builder.AddRetry(retryStrategy);
         });
 
-        services.AddHttpClient(RD_CLIENT)
-                .AddPolicyHandler(retryPolicy);
+        services.AddHttpClient(TORBOX_CLIENT, httpClient =>
+        {
+            httpClient.DefaultRequestHeaders.Add("User-Agent", UserAgent);
+        })
+        .AddResilienceHandler("TorBox-Limits", (builder, ctx) =>
+        {
+            builder.AddRateLimiter(new RateLimiterStrategyOptions
+            {
+                // Acquire 1 permit; throw RateLimiterRejectedException if unavailable
+                RateLimiter = args => TorboxPerSecondLimiter.AcquireAsync(1, args.Context.CancellationToken),
+
+                // Optional notification just before rejection is thrown
+                OnRejected = _ => default
+            });
+
+            // Keep your existing retry here so transient failures still retry
+            builder.AddRetry(retryStrategy);
+        });
+
+        services.AddHttpClient(TORBOX_CLIENT_CREATETORRENT, httpClient =>
+        {
+            httpClient.DefaultRequestHeaders.Add("User-Agent", UserAgent);
+        })
+        .AddResilienceHandler("TorBox-CreateTorrent-Limits", (builder, ctx) =>
+        {
+            // First limiter: 10 per minute
+            builder.AddRateLimiter(new RateLimiterStrategyOptions
+            {
+                RateLimiter = args => TorboxCreateTorrentPerMinuteLimiter.AcquireAsync(1, args.Context.CancellationToken),
+                OnRejected = _ => default
+            });
+
+            // Second limiter: 60 per hour
+            builder.AddRateLimiter(new RateLimiterStrategyOptions
+            {
+                RateLimiter = args => TorboxCreateTorrentPerHourLimiter.AcquireAsync(1, args.Context.CancellationToken),
+                OnRejected = _ => default
+            });
+            builder.AddRetry(retryStrategy);
+        });
     }
 }

--- a/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs
@@ -12,7 +12,7 @@ namespace RdtClient.Service.Services.TorrentClients;
 public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClientFactory httpClientFactory, IDownloadableFileFilter fileFilter) : ITorrentClient
 {
     private TimeSpan? _offset;
-    private TorBoxNetClient GetClient()
+    private TorBoxNetClient GetClient(String? client = null)
     {
         try
         {
@@ -23,7 +23,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
                 throw new("TorBox API Key not set in the settings");
             }
 
-            var httpClient = httpClientFactory.CreateClient(); 
+            var httpClient = httpClientFactory.CreateClient(client ?? DiConfig.TORBOX_CLIENT); 
             httpClient.Timeout = TimeSpan.FromSeconds(Settings.Get.Provider.Timeout);
 
             var torBoxNetClient = new TorBoxNetClient(null, httpClient, 5);
@@ -124,7 +124,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
     {
         var user = await GetClient().User.GetAsync(true);
 
-        var result = await GetClient().Torrents.AddMagnetAsync(magnetLink, user.Data?.Settings?.SeedTorrents ?? 3, false);
+        var result = await GetClient(DiConfig.TORBOX_CLIENT_CREATETORRENT).Torrents.AddMagnetAsync(magnetLink, user.Data?.Settings?.SeedTorrents ?? 3, false);
 
         if (result.Error == "ACTIVE_LIMIT")
         {
@@ -139,7 +139,7 @@ public class TorBoxTorrentClient(ILogger<TorBoxTorrentClient> logger, IHttpClien
     {
         var user = await GetClient().User.GetAsync(true);
 
-        var result = await GetClient().Torrents.AddFileAsync(bytes, user.Data?.Settings?.SeedTorrents ?? 3);
+        var result = await GetClient(DiConfig.TORBOX_CLIENT_CREATETORRENT).Torrents.AddFileAsync(bytes, user.Data?.Settings?.SeedTorrents ?? 3);
         if (result.Error == "ACTIVE_LIMIT")
         {
             using var stream = new MemoryStream(bytes);


### PR DESCRIPTION
### **User description**
- Added retry that uses Retry-After if available
- Added specific TorBox Hard Rate Limits

Ran into issues with adding loads of content to be downloaded by rdt-client, constantly seeing on active torrents that rate limit exceeded.

This has been completely vibe coded, but it built and I deployed a docker image at colinajd/rdt-client and am currently using it and all functionality seems to be working as expected.

Please review if you think this is a worthwhile attempt at resolving the specific rate limiting issue/ TorBox use case


___

### **PR Type**
Enhancement


___

### **Description**
- Implement TorBox-specific rate limiting with sliding window algorithm

- Add per-second and per-minute/hour limits for create torrent operations

- Migrate from Polly to Microsoft.Extensions.Http.Resilience for retry handling

- Support Retry-After header parsing for server-provided delay preferences

- Create separate HTTP clients for general and torrent creation requests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Requests"] --> B["RD_CLIENT<br/>Default Retry Policy"]
  A --> C["TORBOX_CLIENT<br/>5 req/sec Rate Limit"]
  A --> D["TORBOX_CLIENT_CREATETORRENT<br/>10/min + 60/hour Limits"]
  B --> E["Exponential Backoff<br/>+ Retry-After Support"]
  C --> E
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DiConfig.cs</strong><dd><code>Implement TorBox rate limiting and retry strategy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/RdtClient.Service/DiConfig.cs

<ul><li>Added three static <code>SlidingWindowRateLimiter</code> instances for TorBox rate <br>limiting (5/sec general, 10/min and 60/hour for create torrent)<br> <li> Replaced Polly HTTP resilience with <br>Microsoft.Extensions.Http.Resilience framework<br> <li> Implemented custom retry strategy with Retry-After header parsing and <br>exponential backoff with jitter<br> <li> Created three named HTTP clients: <code>RD_CLIENT</code>, <code>TORBOX_CLIENT</code>, and <br><code>TORBOX_CLIENT_CREATETORRENT</code> with appropriate resilience handlers<br> <li> Updated imports to use new resilience libraries and removed deprecated <br>Polly.Extensions.Http</ul>


</details>


  </td>
  <td><a href="https://github.com/rogerfar/rdt-client/pull/895/files#diff-78c3986abf7d0ad947324b9bd1ef7daa9511536766bd164f91ed26ce385c575c">+134/-11</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TorBoxTorrentClient.cs</strong><dd><code>Route torrent creation through rate-limited client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs

<ul><li>Modified <code>GetClient()</code> method to accept optional client name parameter <br>for selecting appropriate HTTP client<br> <li> Updated <code>AddMagnet()</code> to use <code>TORBOX_CLIENT_CREATETORRENT</code> client for <br>torrent creation requests<br> <li> Updated <code>AddFile()</code> to use <code>TORBOX_CLIENT_CREATETORRENT</code> client for <br>torrent creation requests<br> <li> Maintains backward compatibility by defaulting to <code>TORBOX_CLIENT</code> when <br>no client specified</ul>


</details>


  </td>
  <td><a href="https://github.com/rogerfar/rdt-client/pull/895/files#diff-42024651e027aaf41f60fc093268b98ba1fa9b18461d1ac35a196e4776908ba0">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

