### PR TITLE
Better Retry and Provider Limit handling

### DIFF
--- a/client/src/app/models/rate-limit-status.model.ts
+++ b/client/src/app/models/rate-limit-status.model.ts
@@ -1,0 +1,4 @@
+export interface RateLimitStatus {
+  nextDequeueTime: Date | null;
+  secondsRemaining: number;
+}

--- a/client/src/app/torrent-table/torrent-table.component.html
+++ b/client/src/app/torrent-table/torrent-table.component.html
@@ -13,6 +13,13 @@
     <small>Last check: {{ diskSpaceStatus.lastCheckTime | date: 'short' }}</small>
   </div>
 }
+@if (rateLimitStatus?.nextDequeueTime) {
+  <div class="notification is-warning">
+    <strong>Debrid provider rate limit reached</strong>
+    <br />
+    New torrents will not be added until {{ rateLimitStatus.nextDequeueTime | date: 'medium' }}
+  </div>
+}
 <div class="table-container">
   <table class="table is-fullwidth is-hoverable">
     <thead>

--- a/client/src/app/torrent-table/torrent-table.component.ts
+++ b/client/src/app/torrent-table/torrent-table.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Torrent } from '../models/torrent.model';
 import { DiskSpaceStatus } from '../models/disk-space-status.model';
+import { RateLimitStatus } from '../models/rate-limit-status.model';
 import { TorrentService } from '../torrent.service';
 import { forkJoin, Observable } from 'rxjs';
 import { FormsModule } from '@angular/forms';
@@ -21,8 +22,8 @@ export class TorrentTableComponent implements OnInit {
   public torrents: Torrent[] = [];
   public selectedTorrents: string[] = [];
   public error: string;
-  public sortProperty = 'rdName';
-  public sortDirection: 'asc' | 'desc' = 'asc';
+  public sortProperty = 'added';
+  public sortDirection: 'asc' | 'desc' = 'desc';
 
   public isDeleteModalActive: boolean;
   public deleteError: string;
@@ -50,6 +51,7 @@ export class TorrentTableComponent implements OnInit {
   public updateSettingsTorrentLifetime: number;
 
   public diskSpaceStatus: DiskSpaceStatus | null = null;
+  public rateLimitStatus: RateLimitStatus | null = null;
 
   constructor(
     private router: Router,
@@ -65,6 +67,16 @@ export class TorrentTableComponent implements OnInit {
 
     this.torrentService.diskSpaceStatus$.subscribe((status) => {
       this.diskSpaceStatus = status;
+    });
+
+    this.torrentService.getRateLimitStatus().subscribe({
+      next: (status) => {
+        this.rateLimitStatus = status;
+      },
+    });
+
+    this.torrentService.rateLimitStatus$.subscribe((status) => {
+      this.rateLimitStatus = status;
     });
 
     this.torrentService.update$.subscribe((result) => {

--- a/client/src/app/torrent.service.ts
+++ b/client/src/app/torrent.service.ts
@@ -4,6 +4,7 @@ import * as signalR from '@microsoft/signalr';
 import { Observable, Subject } from 'rxjs';
 import { Torrent, TorrentFileAvailability } from './models/torrent.model';
 import { DiskSpaceStatus } from './models/disk-space-status.model';
+import { RateLimitStatus } from './models/rate-limit-status.model';
 import { APP_BASE_HREF } from '@angular/common';
 
 @Injectable({
@@ -12,6 +13,7 @@ import { APP_BASE_HREF } from '@angular/common';
 export class TorrentService {
   public update$: Subject<Torrent[]> = new Subject();
   public diskSpaceStatus$: Subject<DiskSpaceStatus> = new Subject();
+  public rateLimitStatus$: Subject<RateLimitStatus> = new Subject();
 
   private connection: signalR.HubConnection;
 
@@ -40,6 +42,10 @@ export class TorrentService {
       this.diskSpaceStatus$.next(status);
     });
 
+    this.connection.on('rateLimitStatus', (status: any) => {
+      this.rateLimitStatus$.next(status);
+    });
+
     this.connection.onreconnected(() => {
       this.getDiskSpaceStatus().subscribe({
         next: (status) => {
@@ -63,6 +69,10 @@ export class TorrentService {
 
   public getDiskSpaceStatus(): Observable<DiskSpaceStatus | null> {
     return this.http.get<DiskSpaceStatus | null>(`${this.baseHref}Api/Torrents/DiskSpaceStatus`);
+  }
+
+  public getRateLimitStatus(): Observable<RateLimitStatus | null> {
+    return this.http.get<RateLimitStatus | null>(`${this.baseHref}Api/Torrents/RateLimitStatus`);
   }
 
   public uploadMagnet(magnetLink: string, torrent: Torrent): Observable<void> {

--- a/server/RdtClient.Data/Models/Internal/RateLimitException.cs
+++ b/server/RdtClient.Data/Models/Internal/RateLimitException.cs
@@ -1,0 +1,6 @@
+namespace RdtClient.Data.Models.Internal;
+
+public class RateLimitException(String message, TimeSpan retryAfter) : Exception(message)
+{
+    public TimeSpan RetryAfter { get; } = retryAfter;
+}

--- a/server/RdtClient.Data/Models/Internal/RateLimitStatus.cs
+++ b/server/RdtClient.Data/Models/Internal/RateLimitStatus.cs
@@ -1,0 +1,7 @@
+namespace RdtClient.Data.Models.Internal;
+
+public class RateLimitStatus
+{
+    public DateTimeOffset? NextDequeueTime { get; set; }
+    public Double SecondsRemaining { get; set; }
+}

--- a/server/RdtClient.Service.Test/Helpers/RateLimitHandlerTest.cs
+++ b/server/RdtClient.Service.Test/Helpers/RateLimitHandlerTest.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using RdtClient.Data.Models.Internal;
+using RdtClient.Service.Helpers;
+using Xunit;
+
+namespace RdtClient.Service.Test.Helpers;
+
+public class RateLimitHandlerTest
+{
+    [Fact]
+    public async Task SendAsync_ThrowsRateLimitException_On429WithRetryAfter()
+    {
+        // Arrange
+        var handler = new RateLimitHandler
+        {
+            InnerHandler = new MockHttpMessageHandler(HttpStatusCode.TooManyRequests, 3600)
+        };
+        var client = new HttpClient(handler);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<RateLimitException>(() => client.GetAsync("http://example.com"));
+        Assert.Equal(TimeSpan.FromSeconds(3600), ex.RetryAfter);
+        Assert.Equal("TorBox rate limit exceeded", ex.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_ThrowsRateLimitException_On429WithoutRetryAfter()
+    {
+        // Arrange
+        var handler = new RateLimitHandler
+        {
+            InnerHandler = new MockHttpMessageHandler(HttpStatusCode.TooManyRequests, null)
+        };
+        var client = new HttpClient(handler);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<RateLimitException>(() => client.GetAsync("http://example.com"));
+        Assert.Equal(TimeSpan.FromMinutes(2), ex.RetryAfter);
+    }
+
+    private class MockHttpMessageHandler(HttpStatusCode statusCode, Int32? retryAfterSeconds) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(statusCode);
+            if (retryAfterSeconds.HasValue)
+            {
+                response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(TimeSpan.FromSeconds(retryAfterSeconds.Value));
+            }
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/server/RdtClient.Service.Test/RdtClient.Service.Test.csproj
+++ b/server/RdtClient.Service.Test/RdtClient.Service.Test.csproj
@@ -20,6 +20,7 @@
         <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.0.16" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.0.16" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.16" />
+        <PackageReference Include="TorBox.NET" Version="1.6.2" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/server/RdtClient.Service/DiConfig.cs
+++ b/server/RdtClient.Service/DiConfig.cs
@@ -4,8 +4,11 @@ using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Polly;
-using Polly.Extensions.Http;
+using Polly.Timeout;
+using RateLimitHeaders.Polly;
+using RdtClient.Data.Models.Internal;
 using RdtClient.Service.BackgroundServices;
+using RdtClient.Service.Helpers;
 using RdtClient.Service.Middleware;
 using RdtClient.Service.Services;
 using RdtClient.Service.Services.TorrentClients;
@@ -16,6 +19,7 @@ namespace RdtClient.Service;
 public static class DiConfig
 {
     public const String RD_CLIENT = "RdClient";
+    public const String TORBOX_CLIENT = "TorBoxClient";
     public static readonly String UserAgent = $"rdt-client {Assembly.GetEntryAssembly()?.GetName().Version}";
 
     public static void RegisterRdtServices(this IServiceCollection services)
@@ -58,11 +62,6 @@ public static class DiConfig
 
     public static void RegisterHttpClients(this IServiceCollection services)
     {
-        var retryPolicy = HttpPolicyExtensions
-                          .HandleTransientHttpError()
-                          .OrResult(r => r.StatusCode == HttpStatusCode.TooManyRequests)
-                          .WaitAndRetryAsync(retryCount: 5, sleepDurationProvider: attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)));
-
         services.AddHttpClient();
         services.ConfigureHttpClientDefaults(builder =>
         {
@@ -72,7 +71,64 @@ public static class DiConfig
             });
         });
 
+        services.AddTransient<RateLimitHandler>();
+        
         services.AddHttpClient(RD_CLIENT)
-                .AddPolicyHandler(retryPolicy);
+                .AddHttpMessageHandler<RateLimitHandler>()
+                .AddResilienceHandler("rd_client_handler", ConfigureResiliencePipeline);
+
+        services.AddHttpClient(TORBOX_CLIENT)
+                .AddHttpMessageHandler<RateLimitHandler>()
+                .AddResilienceHandler("torbox_client_handler", ConfigureResiliencePipeline);
+    }
+
+    private static void ConfigureResiliencePipeline(ResiliencePipelineBuilder<HttpResponseMessage> builder)
+    {
+        builder.AddRateLimitHeaders(options =>
+        {
+            options.EnableProactiveThrottling = true;
+        });
+        builder.AddRetry(new()
+        {
+            ShouldHandle = args => args.Outcome switch
+            {
+                { Exception: HttpRequestException } => PredicateResult.True(),
+                { Result.StatusCode: HttpStatusCode.RequestTimeout } => PredicateResult.True(),
+                { Result.StatusCode: HttpStatusCode.TooManyRequests } => PredicateResult.True(),
+                { Result.StatusCode: >= HttpStatusCode.InternalServerError } => PredicateResult.True(),
+                _ => PredicateResult.False()
+            },
+            MaxRetryAttempts = 2,
+            BackoffType = DelayBackoffType.Exponential,
+            Delay = TimeSpan.FromSeconds(2),
+            UseJitter = true,
+            DelayGenerator = args =>
+            {
+                if (args.Outcome.Result is { StatusCode: HttpStatusCode.TooManyRequests } response)
+                {
+                    var retryAfter = response.Headers.RetryAfter;
+                    var delay = retryAfter?.Delta ?? (retryAfter?.Date.HasValue == true ? retryAfter.Date.Value - DateTimeOffset.UtcNow : TimeSpan.FromMinutes(2));
+
+                    if (delay < TimeSpan.Zero)
+                    {
+                        delay = TimeSpan.FromMinutes(2);
+                    }
+
+                    if (delay >= TimeSpan.FromSeconds(Settings.Get.Provider.Timeout))
+                    {
+                        throw new RateLimitException("TorBox rate limit exceeded", delay);
+                    }
+
+                    return new ValueTask<TimeSpan?>(delay);
+                }
+
+                return new ValueTask<TimeSpan?>((TimeSpan?)null);
+            }
+        });
+
+        builder.AddTimeout(new TimeoutStrategyOptions
+        {
+            TimeoutGenerator = _ => new ValueTask<TimeSpan>(TimeSpan.FromSeconds(Settings.Get.Provider.Timeout))
+        });
     }
 }

--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="MonoTorrent" Version="3.0.2" />
     <PackageReference Include="Polly" Version="8.6.4" />
     <PackageReference Include="Premiumize.NET" Version="1.0.10" />
+    <PackageReference Include="RateLimitHeaders" Version="1.0.0" />
+    <PackageReference Include="RateLimitHeaders.Polly" Version="1.0.0" />
     <PackageReference Include="RD.NET" Version="2.1.11" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
@@ -25,7 +27,7 @@
     <PackageReference Include="Synology.Api.Client" Version="0.3.93" />
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.0.16" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.16" />
-    <PackageReference Include="TorBox.NET" Version="1.5.0" />
+    <PackageReference Include="TorBox.NET" Version="1.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/server/RdtClient.Service/Services/RemoteService.cs
+++ b/server/RdtClient.Service/Services/RemoteService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.SignalR;
+using RdtClient.Data.Models.Internal;
 
 namespace RdtClient.Service.Services;
 
@@ -23,5 +24,10 @@ public class RemoteService(IHubContext<RdtHub> hub, Torrents torrents)
     public async Task UpdateDiskSpaceStatus(Object status)
     {
         await hub.Clients.All.SendCoreAsync("diskSpaceStatus", [status]);
+    }
+
+    public async Task UpdateRateLimitStatus(RateLimitStatus status)
+    {
+        await hub.Clients.All.SendCoreAsync("rateLimitStatus", [status]);
     }
 }

--- a/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/PremiumizeTorrentClient.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using PremiumizeNET;
 using RdtClient.Data.Enums;
 using RdtClient.Data.Models.TorrentClient;
+using RdtClient.Data.Models.Internal;
 using RdtClient.Service.Helpers;
 using RdtClient.Data.Models.Data;
 using Torrent = RdtClient.Data.Models.Data.Torrent;
@@ -91,30 +92,46 @@ public class PremiumizeTorrentClient(ILogger<PremiumizeTorrentClient> logger, IH
 
     public async Task<String> AddMagnet(String magnetLink)
     {
-        var result = await GetClient().Transfers.CreateAsync(magnetLink, "");
-
-        if (result?.Id == null)
+        try
         {
-            throw new("Unable to add magnet link");
+            var result = await GetClient().Transfers.CreateAsync(magnetLink, "");
+
+            if (result?.Id == null)
+            {
+                throw new("Unable to add magnet link");
+            }
+
+            var resultId = result.Id ?? throw new($"Invalid responseID {result.Id}");
+
+            return resultId;
         }
-
-        var resultId = result.Id ?? throw new($"Invalid responseID {result.Id}");
-
-        return resultId;
+        catch (Exception ex) when (ex.Message.Contains("slow_down", StringComparison.OrdinalIgnoreCase) ||
+                           ex.Message.Contains("rate limit exceeded", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new RateLimitException(ex.Message, TimeSpan.FromMinutes(2));
+        }
     }
 
     public async Task<String> AddFile(Byte[] bytes)
     {
-        var result = await GetClient().Transfers.CreateAsync(bytes, "");
-
-        if (result?.Id == null)
+        try
         {
-            throw new("Unable to add torrent file");
+            var result = await GetClient().Transfers.CreateAsync(bytes, "");
+
+            if (result?.Id == null)
+            {
+                throw new("Unable to add torrent file");
+            }
+
+            var resultId = result.Id ?? throw new($"Invalid responseID {result.Id}");
+
+            return resultId;
         }
-
-        var resultId = result.Id ?? throw new($"Invalid responseID {result.Id}");
-
-        return resultId;
+        catch (Exception ex) when (ex.Message.Contains("slow_down", StringComparison.OrdinalIgnoreCase) ||
+                           ex.Message.Contains("rate limit exceeded", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new RateLimitException(ex.Message, TimeSpan.FromMinutes(2));
+        }
     }
 
     public Task<IList<TorrentClientAvailableFile>> GetAvailableFiles(String hash)

--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -11,12 +11,14 @@ using System.Text.Json;
 
 namespace RdtClient.Service.Services;
 
-public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Downloads downloads)
+public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Downloads downloads, RemoteService remoteService)
 {
     public static readonly ConcurrentDictionary<Guid, DownloadClient> ActiveDownloadClients = new();
     public static readonly ConcurrentDictionary<Guid, UnpackClient> ActiveUnpackClients = new();
 
     public static Boolean IsPausedForLowDiskSpace { get; set; }
+
+    public static DateTimeOffset NextDequeueTime { get; private set; } = DateTimeOffset.MinValue;
 
     private readonly HttpClient _httpClient = new()
     {
@@ -323,27 +325,51 @@ public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Dow
 
         if (torrentsToAddToProvider.Count != 0)
         {
-            var downloadingTorrentsCount = allTorrents.Count(m => m.RdStatus is not (TorrentStatus.Queued or TorrentStatus.Finished or TorrentStatus.Error));
-
-            var maxParallelDownloads = Settings.Get.Provider.MaxParallelDownloads;
-
-            logger.LogDebug("Currently downloading {downloadingTorrentCount}/{maxParallelDownloads} torrents, {queuedCount} queued.",
-                            downloadingTorrentsCount,
-                            maxParallelDownloads,
-                            torrentsToAddToProvider.Count);
-
-            var dequeueCount = maxParallelDownloads == 0 ? torrentsToAddToProvider.Count : maxParallelDownloads - downloadingTorrentsCount;
-
-            foreach (var torrent in torrentsToAddToProvider.Take(dequeueCount))
+            if (DateTimeOffset.Now < NextDequeueTime)
             {
-                try
+                logger.LogDebug($"Dequeuing torrents is paused until {NextDequeueTime}, {NextDequeueTime - DateTimeOffset.Now} remaining");
+            }
+            else
+            {
+                if (NextDequeueTime != DateTimeOffset.MinValue)
                 {
-                    await torrents.DequeueFromDebridQueue(torrent);
+                    NextDequeueTime = DateTimeOffset.MinValue;
+
+                    await remoteService.UpdateRateLimitStatus(new RateLimitStatus
+                    {
+                        NextDequeueTime = null,
+                        SecondsRemaining = 0
+                    });
                 }
-                catch (Exception ex)
+
+                var downloadingTorrentsCount = allTorrents.Count(m => m.RdStatus is not (TorrentStatus.Queued or TorrentStatus.Finished or TorrentStatus.Error));
+
+                var maxParallelDownloads = Settings.Get.Provider.MaxParallelDownloads;
+
+                logger.LogDebug("Currently downloading {downloadingTorrentCount}/{maxParallelDownloads} torrents, {queuedCount} queued.",
+                                downloadingTorrentsCount,
+                                maxParallelDownloads,
+                                torrentsToAddToProvider.Count);
+
+                var dequeueCount = maxParallelDownloads == 0 ? torrentsToAddToProvider.Count : maxParallelDownloads - downloadingTorrentsCount;
+
+                foreach (var torrent in torrentsToAddToProvider.Take(dequeueCount))
                 {
-                    await torrents.UpdateComplete(torrent.TorrentId, $"Could not add to provider: {ex.Message}", DateTimeOffset.Now, true);
-                    logger.LogWarning(ex, "Could not dequeue torrent {torrentId}", torrent.TorrentId);
+                    try
+                    {
+                        await torrents.DequeueFromDebridQueue(torrent);
+                    }
+                    catch (RateLimitException ex)
+                    {
+                        await SetRateLimit(ex.RetryAfter, ex.Message);
+
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        await torrents.UpdateComplete(torrent.TorrentId, $"Could not add to provider: {ex.Message}", DateTimeOffset.Now, true);
+                        logger.LogWarning(ex, "Could not dequeue torrent {torrentId}", torrent.TorrentId);
+                    }
                 }
             }
         }
@@ -696,6 +722,19 @@ public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Dow
         {
             Log($"TorrentRunner Tick End (took {sw.ElapsedMilliseconds}ms)");
         }
+    }
+
+    public async Task SetRateLimit(TimeSpan retryAfter, String message)
+    {
+        NextDequeueTime = DateTimeOffset.Now.Add(retryAfter);
+
+        Log($"Rate-limit reached, pausing dequeuing for {retryAfter.TotalMinutes} minutes (until {NextDequeueTime}): {message}");
+
+        await remoteService.UpdateRateLimitStatus(new RateLimitStatus
+        {
+            NextDequeueTime = NextDequeueTime,
+            SecondsRemaining = retryAfter.TotalSeconds
+        });
     }
 
     private void Log(String message, Download? download, Torrent? torrent)

--- a/server/RdtClient.Web/Controllers/TorrentsController.cs
+++ b/server/RdtClient.Web/Controllers/TorrentsController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MonoTorrent;
+using RdtClient.Data.Models.Internal;
 using RdtClient.Data.Models.TorrentClient;
 using RdtClient.Service.Helpers;
 using RdtClient.Service.Services;
@@ -51,6 +52,28 @@ public class TorrentsController(ILogger<TorrentsController> logger, Torrents tor
     {
         var status = RdtClient.Service.BackgroundServices.DiskSpaceMonitor.GetCurrentStatus();
         return Ok(status);
+    }
+
+    [HttpGet]
+    [Route("RateLimitStatus")]
+    public ActionResult<RateLimitStatus> GetRateLimitStatus()
+    {
+        var nextDequeueTime = TorrentRunner.NextDequeueTime;
+
+        if (nextDequeueTime < DateTimeOffset.Now)
+        {
+            return Ok(new RateLimitStatus
+            {
+                NextDequeueTime = null,
+                SecondsRemaining = 0
+            });
+        }
+
+        return Ok(new RateLimitStatus
+        {
+            NextDequeueTime = nextDequeueTime,
+            SecondsRemaining = (nextDequeueTime - DateTimeOffset.Now).TotalSeconds
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
### **User description**
* It'll attempt a retry, and respect Retry-After headers if present.
* Remove ACTIVE_LIMIT error checks in TorBox, these conditions can never be reached as TorBox doesn't queue whin this happens, and TorBoxNET throws an exception for the error.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace Polly HTTP retry policy with standard resilience handler

- Implement Retry-After header support for respecting server delays

- Remove unreachable ACTIVE_LIMIT error handling in TorBox client

- Simplify retry logic with exponential backoff and jitter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Polly Policy"] -->|"Replace with"| B["Standard Resilience Handler"]
  B -->|"Supports"| C["Retry-After Headers"]
  B -->|"Includes"| D["Exponential Backoff + Jitter"]
  E["TorBox Client"] -->|"Remove"| F["Unreachable ACTIVE_LIMIT Checks"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DiConfig.cs</strong><dd><code>Migrate to standard resilience handler with Retry-After support</code></dd></summary>
<hr>

server/RdtClient.Service/DiConfig.cs

<ul><li>Remove unused <code>System.Net</code> and <code>Polly.Extensions.Http</code> imports<br> <li> Replace custom Polly retry policy with <code>AddStandardResilienceHandler</code><br> <li> Add Retry-After header parsing in custom delay generator<br> <li> Configure exponential backoff with jitter and 10-second timeout</ul>


</details>


  </td>
  <td><a href="https://github.com/rogerfar/rdt-client/pull/912/files#diff-78c3986abf7d0ad947324b9bd1ef7daa9511536766bd164f91ed26ce385c575c">+30/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TorBoxTorrentClient.cs</strong><dd><code>Remove unreachable ACTIVE_LIMIT error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/RdtClient.Service/Services/TorrentClients/TorBoxTorrentClient.cs

<ul><li>Remove ACTIVE_LIMIT error handling from <code>AddMagnet</code> method<br> <li> Remove ACTIVE_LIMIT error handling from <code>AddFile</code> method<br> <li> Simplify return logic to directly use API response data</ul>


</details>


  </td>
  <td><a href="https://github.com/rogerfar/rdt-client/pull/912/files#diff-42024651e027aaf41f60fc093268b98ba1fa9b18461d1ac35a196e4776908ba0">+0/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

