### PR TITLE
Fix qBittorrent Health Check API for Cleanuparr & others

### DIFF
--- a/server/RdtClient.Web/Controllers/QBittorrentController.cs
+++ b/server/RdtClient.Web/Controllers/QBittorrentController.cs
@@ -62,6 +62,7 @@ public class QBittorrentController(ILogger<QBittorrentController> logger, QBitto
         return Ok();
     }
 
+    [AllowAnonymous]
     [Route("app/version")]
     [HttpGet]
     [HttpPost]
@@ -70,6 +71,7 @@ public class QBittorrentController(ILogger<QBittorrentController> logger, QBitto
         return Ok("v4.3.2");
     }
 
+    [AllowAnonymous]
     [Route("app/webapiVersion")]
     [HttpGet]
     [HttpPost]
@@ -78,6 +80,7 @@ public class QBittorrentController(ILogger<QBittorrentController> logger, QBitto
         return Ok("2.7");
     }
 
+    [AllowAnonymous]
     [Route("app/buildInfo")]
     [HttpGet]
     [HttpPost]


### PR DESCRIPTION
Based on issue #867 and @ajax1337 suggestion, the fix requires adding `[AllowAnonymous]` attribute to three health check methods in QBittorrentController.cs:

- [x] Add `[AllowAnonymous]` to `AppVersion()` method (line 65)
- [x] Add `[AllowAnonymous]` to `AppWebVersion()` method (line 73)  
- [x] Add `[AllowAnonymous]` to `AppBuildInfo()` method (line 81)
- [x] Validate Fix is working locally
- [x] Run any existing tests to ensure no regressions

This fix allows Cleanuparr to successfully connect to RDT Client by making the health check endpoints accessible without authentication, matching real qBittorrent behavior. The three endpoints affected are:
- /api/v2/app/version
- /api/v2/app/webapiVersion
- /api/v2/app/buildInfo

**Issue:** Cleanuparr's health check calls `/api/v2/app/webapiVersion` to verify the connection, but RDT Client requires authentication for that endpoint. When authentication fails, it returns HTML login page instead of JSON, causing Cleanuparr to error with "No valid download clients found."

**Solution:** Add `[AllowAnonymous]` attribute to the three app health check endpoints to match real qBittorrent behavior which allows anonymous access to these endpoints.

Fixes #867