### PR TITLE
Update default torrent sorting to `added` in descending order

### DIFF
--- a/client/src/app/torrent-table/torrent-table.component.ts
+++ b/client/src/app/torrent-table/torrent-table.component.ts
@@ -96,9 +96,12 @@ export class TorrentTableComponent implements OnInit {
   }
 
   public sort(property: string): void {
-    const isSameProperty = this.sortProperty === property;
-    this.sortProperty = property;
-    this.sortDirection = isSameProperty ? (this.sortDirection === 'asc' ? 'desc' : 'asc') : this.sortDirection;
+    if (this.sortProperty === property) {
+      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortProperty = property;
+      this.sortDirection = 'desc';
+    }
 
     // Persist sort settings
     try {


### PR DESCRIPTION
I made this change on my end, though it's possibly a bit subjective.

It seems like this would be the preferred default sorting.

CLOSES #927 
