### PR TITLE
Fix ETA calculation for QBittorrent API

### DIFF
--- a/server/RdtClient.Service.Test/Services/QBittorrentTest.cs
+++ b/server/RdtClient.Service.Test/Services/QBittorrentTest.cs
@@ -54,4 +54,73 @@ public class QBittorrentTest
         Assert.Equal("hash1", result[0].Hash);
         Assert.Equal("Torrent 1", result[0].Name);
     }
+    
+    [Fact]
+    public async Task TorrentInfo_ShouldReport100Percent_WhenDownloadIsComplete()
+    {
+        // Arrange
+        var downloadId = Guid.NewGuid();
+        var torrentId = Guid.NewGuid();
+        var allTorrents = new List<Torrent>
+        {
+            new()
+            {
+                TorrentId = torrentId,
+                Hash = "hash1",
+                RdName = "Torrent 1",
+                RdProgress = 100, // Real-Debrid is 100%
+                Type = DownloadType.Torrent,
+                Downloads = new List<Download>
+                {
+                    new() { DownloadId = downloadId, TorrentId = torrentId }
+                }
+            }
+        };
+
+        _torrentsMock.Setup(m => m.Get()).ReturnsAsync(allTorrents);
+        // Local download is also 100%
+        _torrentsMock.Setup(m => m.GetDownloadStats(downloadId)).Returns((0, 1000, 1000));
+
+        // Act
+        var result = await _qBittorrent.TorrentInfo();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(1.0f, result[0].Progress);
+    }
+
+    [Fact]
+    public async Task TorrentInfo_ShouldReport90Percent_WhenRDIs100AndLocalIs80()
+    {
+        // Arrange
+        var downloadId = Guid.NewGuid();
+        var torrentId = Guid.NewGuid();
+        var allTorrents = new List<Torrent>
+        {
+            new()
+            {
+                TorrentId = torrentId,
+                Hash = "hash1",
+                RdName = "Torrent 1",
+                RdProgress = 100, // Real-Debrid is 100%
+                Type = DownloadType.Torrent,
+                Downloads = new List<Download>
+                {
+                    new() { DownloadId = downloadId, TorrentId = torrentId }
+                }
+            }
+        };
+
+        _torrentsMock.Setup(m => m.Get()).ReturnsAsync(allTorrents);
+        // Local download is 80%
+        _torrentsMock.Setup(m => m.GetDownloadStats(downloadId)).Returns((0, 1000, 800));
+
+        // Act
+        var result = await _qBittorrent.TorrentInfo();
+
+        // Assert
+        Assert.Single(result);
+        // Current behavior is (1.0 + 0.8) / 2 = 0.9
+        Assert.Equal(0.9f, result[0].Progress);
+    }
 }

--- a/server/RdtClient.Service/Services/QBittorrent.cs
+++ b/server/RdtClient.Service/Services/QBittorrent.cs
@@ -224,14 +224,26 @@ public class QBittorrent(ILogger<QBittorrent> logger, Settings settings, Authent
             var bytesDone = (Int64)(bytesTotal * rdProgress);
 
             Double progress;
-            if (torrent.Downloads is { Count: > 0 })
+            if (torrent.Completed != null)
+            {
+                progress = 1.0;
+            }
+            else if (torrent.Downloads is { Count: > 0 })
             {
                 var dlStats = torrent.Downloads.Select(m => torrents.GetDownloadStats(m.DownloadId)).ToList();
                 var dlBytesDone = dlStats.Sum(m => m.BytesDone);
                 var dlBytesTotal = dlStats.Sum(m => m.BytesTotal);
                 speed = (Int32)(dlStats.Any() ? dlStats.Average(m => m.Speed) : 0);
                 var downloadProgress = dlBytesTotal > 0 ? Math.Clamp((Double)dlBytesDone / dlBytesTotal, 0.0, 1.0) : 0;
-                progress = (rdProgress + downloadProgress) / 2.0;
+
+                if (rdProgress >= 1.0 && downloadProgress >= 1.0)
+                {
+                    progress = 1.0;
+                }
+                else
+                {
+                    progress = (rdProgress + downloadProgress) / 2.0;
+                }
             }
             else
             {


### PR DESCRIPTION
Was missing a case for completed torrents. Differs from Sabnzbd in that QBT uses a single API call for completed an in-progress.

CLOSES #918 #908