### PR TITLE
Add legacy /version/api endpoint

### DIFF
--- a/server/RdtClient.Web/Controllers/QBittorrentController.cs
+++ b/server/RdtClient.Web/Controllers/QBittorrentController.cs
@@ -16,6 +16,16 @@ namespace RdtClient.Web.Controllers;
 public class QBittorrentController(ILogger<QBittorrentController> logger, QBittorrent qBittorrent) : Controller
 {
     [AllowAnonymous]
+    [Route("/version/api")]
+    [HttpGet]
+    [HttpPost]
+    public ActionResult LegacyVersionApi()
+    {
+        // Returning 20 nudges older qB clients to use /api/v2 endpoints.
+        return Content("20", "text/plain");
+    }
+
+    [AllowAnonymous]
     [Route("auth/login")]
     [HttpGet]
     public async Task<ActionResult> AuthLogin([FromQuery] QBAuthLoginRequest request)


### PR DESCRIPTION
Cleanuparr’s uses the `FLM.QBittorrent` library to handle qBittorrent API calls.

To [do a health check](https://github.com/Cleanuparr/Cleanuparr/blob/d0387380085a61bbed2ff63881eda75c41bcc67c/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitService.cs#L103-L105):
* It calls the library's `GetApiVersionAsync`.
* The library's [logic is a bit weird](https://github.com/fedarovich/qbittorrent-net-client/blob/041b117b8ea811358e2f25bffd46ed0f98e264e3/src/QBittorrent.Client/QBittorrentClient.cs#L184-L193):
  * Dirst [it calls the legacy](https://github.com/fedarovich/qbittorrent-net-client/blob/041b117b8ea811358e2f25bffd46ed0f98e264e3/src/QBittorrent.Client/QBittorrentClient.cs#L204-L217) `/version/api` endpoint
  * If it's higher than 18, then it calls the newer `api/v2/app/webapiVersion` endpoint.

Returning `20` from the legacy endpoint makes it switch to the new API which is compatible with RDT-Client's existing logic.

Fixes #867 