### PR TITLE
Always return plain text from `auth/login` API endpoint

### DIFF
--- a/server/RdtClient.Web/Controllers/QBittorrentController.cs
+++ b/server/RdtClient.Web/Controllers/QBittorrentController.cs
@@ -24,22 +24,22 @@ public class QBittorrentController(ILogger<QBittorrentController> logger, QBitto
 
         if (Settings.Get.General.AuthenticationType == AuthenticationType.None)
         {
-            return Ok("Ok.");
+            return Content("Ok.", "text/plain");
         }
 
         if (String.IsNullOrWhiteSpace(request.UserName) || String.IsNullOrEmpty(request.Password))
         {
-            return Ok("Fails.");
+            return Content("Fails.", "text/plain");
         }
 
         var result = await qBittorrent.AuthLogin(request.UserName, request.Password);
 
         if (result)
         {
-            return Ok("Ok.");
+            return Content("Ok.", "text/plain");
         }
 
-        return Ok("Fails.");
+        return Content("Fails.", "text/plain");
     }
         
     [AllowAnonymous]


### PR DESCRIPTION
## Summary
- Force /api/v2/auth/login to return text/plain bodies (`Ok.`/`Fails.`)
- Ignore `Accept`-driven JSON serialization for this endpoint to match qBittorrent behavior

This has the same behavior as the official qBittorrent API and removes an issue preventing to log in with qBitcontroller: fixes https://github.com/rogerfar/rdt-client/issues/872

## Why
qBitController expects exact unquoted `Ok.` from login. With JSON negotiation, ASP.NET can return `"Ok."`, which causes unknown login response errors.

This was tested on my side and confirmed: the official qBittorrent implementation never returns a JSON string, always plain text, regardless of the `Accept` header.

## Scope
- server/RdtClient.Web/Controllers/QBittorrentController.cs only

## Validation
- Manual validation path: `POST /api/v2/auth/login` with `Accept: application/json` should still return plain text `Ok.`/`Fails.` (unquoted).