### PR TITLE
Bump bezzad version

### DIFF
--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AllDebrid.NET" Version="1.0.18" />
     <PackageReference Include="Aria2.NET" Version="1.0.6" />
     <PackageReference Include="DebridLinkFr.NET" Version="1.0.4" />
-    <PackageReference Include="Downloader" Version="5.1.0" />
+    <PackageReference Include="Downloader" Version="5.3.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageReference Include="MonoTorrent" Version="3.0.2" />


### PR DESCRIPTION
Resolves original issue described in #962 

> Downloads fail on Linux containers when filenames contain square brackets or multiple consecutive spaces. On Linux, .NET's Path.GetInvalidFileNameChars() only returns NUL and '/', so characters like [ ] { } that cause issues with shell globbing, URI handling, and various download clients pass through the existing filter unchanged.

issue was determined to be a downstream package issue, patched the downstream stream, and this now brings that patch to rdt-client 