### PR TITLE
Fix DeleteOnError provider retry loop, which causes the delete on error feature to never run

### DIFF
--- a/server/RdtClient.Service.Test/Services/TorrentRunnerTest.cs
+++ b/server/RdtClient.Service.Test/Services/TorrentRunnerTest.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using RdtClient.Data.Data;
+using RdtClient.Data.Enums;
+using RdtClient.Data.Models.Data;
+using RdtClient.Service.Helpers;
+using RdtClient.Service.Services;
+
+namespace RdtClient.Service.Test.Services;
+
+public class TorrentRunnerTest
+{
+    [Fact]
+    public async Task Tick_ShouldNotRequeueCompletedErrorTorrent()
+    {
+        var originalApiKey = Settings.Get.Provider.ApiKey;
+        var originalProvider = Settings.Get.Provider.Provider;
+        var originalMaxParallelDownloads = Settings.Get.Provider.MaxParallelDownloads;
+        var originalDownloadPath = Settings.Get.DownloadClient.DownloadPath;
+
+        TorrentRunner.ActiveDownloadClients.Clear();
+        TorrentRunner.ActiveUnpackClients.Clear();
+
+        try
+        {
+            Settings.Get.Provider.ApiKey = "test-api-key";
+            Settings.Get.Provider.Provider = Provider.RealDebrid;
+            Settings.Get.Provider.MaxParallelDownloads = 1;
+            Settings.Get.DownloadClient.DownloadPath = "/downloads";
+
+            var erroredTorrent = new Torrent
+            {
+                TorrentId = Guid.NewGuid(),
+                Hash = "hash-1",
+                RdName = "Torrent 1",
+                FileOrMagnet = "magnet:?xt=urn:btih:hash-1",
+                Type = DownloadType.Torrent,
+                RdStatus = TorrentStatus.Queued,
+                DeleteOnError = 10,
+                Error = "Could not add to provider: Infringing file",
+                Completed = DateTimeOffset.UtcNow.AddMinutes(-5),
+                Downloads = new List<Download>()
+            };
+
+            var torrentDataMock = new Mock<ITorrentData>(MockBehavior.Strict);
+            torrentDataMock.Setup(m => m.Get()).ReturnsAsync(new List<Torrent>
+            {
+                erroredTorrent
+            });
+
+            var torrents = new Torrents(Mock.Of<ILogger<Torrents>>(),
+                                        torrentDataMock.Object,
+                                        Mock.Of<IDownloads>(),
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!,
+                                        null!);
+
+            var torrentRunner = new TorrentRunner(Mock.Of<ILogger<TorrentRunner>>(),
+                                                  torrents,
+                                                  new Downloads(null!),
+                                                  new RemoteService(null!, torrents),
+                                                  Mock.Of<IHttpClientFactory>(),
+                                                  new RateLimitCoordinator());
+
+            await torrentRunner.Tick();
+
+            torrentDataMock.Verify(m => m.UpdateComplete(It.IsAny<Guid>(),
+                                                         It.IsAny<string?>(),
+                                                         It.IsAny<DateTimeOffset?>(),
+                                                         It.IsAny<bool>()),
+                                   Times.Never);
+        }
+        finally
+        {
+            Settings.Get.Provider.ApiKey = originalApiKey;
+            Settings.Get.Provider.Provider = originalProvider;
+            Settings.Get.Provider.MaxParallelDownloads = originalMaxParallelDownloads;
+            Settings.Get.DownloadClient.DownloadPath = originalDownloadPath;
+            TorrentRunner.ActiveDownloadClients.Clear();
+            TorrentRunner.ActiveUnpackClients.Clear();
+        }
+    }
+}

--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -367,7 +367,7 @@ public class TorrentRunner(
         }
 
         // Process torrents in DebridQueue
-        var torrentsToAddToProvider = allTorrents.Where(m => m.RdId == null && m.RdAdded == null && m.FileOrMagnet != null && m.RdStatus == TorrentStatus.Queued)
+        var torrentsToAddToProvider = allTorrents.Where(m => m.Completed == null && m.Error == null && m.RdId == null && m.RdAdded == null && m.FileOrMagnet != null && m.RdStatus == TorrentStatus.Queued)
                                                  .ToList();
 
         if (torrentsToAddToProvider.Count != 0)


### PR DESCRIPTION
I've been wondering why many of my torrents were in an 'error' state, weren't being deleted after the set amount of time.
After investiating, I found that there is a bug that causes the time limit to never be reached. 

This patch fixes a lifecycle bug that prevents `DeleteOnError` from expiring when a torrent fails before it is ever added to the debrid provider.

In my specific case, it was a Sonarr or qBittorrent-added torrent that failed with:
`Could not add to provider: Infringing file` but this would happen on any other 'error' status.

Initially I had the DeleteOnError field set to 60 minutes, but even when the torrent had `DeleteOnError = 10`, it never cleared.

## The actual issue

`TorrentRunner` was still selecting errored queued torrents for `torrentsToAddToProvider` as long as all of the following were true:

- `RdId == null`
- `RdAdded == null`
- `FileOrMagnet != null`
- `RdStatus == Queued`

That was enough to reprocess torrents that had already been marked with an error.

When `DequeueFromDebridQueue()` failed, the runner called:

- `torrents.UpdateComplete(torrentId, "Could not add to provider: ...", datetime, true)`

That writes both `Completed` and `Error`.

Because the same torrent still matched the provider queue selector on the next tick, `UpdateComplete()` kept firing again and again. The `Completed` timestamp kept moving forward, so:

- `Completed + DeleteOnError`

never aged out.

## My live Reproduction

Observed on my live instance with a torrent with the following:
- `RdId = null`
- `RdAdded = null`
- `RdStatus = Queued`
- `Error = Could not add to provider: Infringing file`
- `DeleteOnError = 10`
- `Completed` kept being refreshed instead of aging out toward deletion

That meant the existing error-expiry block in `TorrentRunner` was correct, but the queue selector kept resetting the timer before it could ever elapse.

## Changes

- exclude already completed torrents from `torrentsToAddToProvider`
- exclude already errored torrents from `torrentsToAddToProvider`
- leave the existing queued-provider conditions unchanged
- add a regression test proving an errored queued torrent is not sent back through the provider-add path

## Before / After

### Before

- queued torrent hits provider-add failure
- torrent is marked with `Completed` and `Error`
- same torrent still matches `torrentsToAddToProvider` on the next tick
- `Completed` is written again
- `DeleteOnError` never reaches its expiry time

### After

- queued torrent hits provider-add failure once
- torrent is marked with `Completed` and `Error`
- torrent no longer matches `torrentsToAddToProvider`
- `Completed` stays fixed
- the existing error-expiry logic can delete the torrent after `DeleteOnError` minutes

## Validation

I validated the patch with:

- feature branch commit: `a62d847`
- targeted remote test:
  - `dotnet test RdtClient.Service.Test/RdtClient.Service.Test.csproj --filter TorrentRunnerTest`
  - result: `Passed: 1, Failed: 0`
- full remote service test run on feature branch:
  - `dotnet test RdtClient.Service.Test/RdtClient.Service.Test.csproj`
  - result: `Passed: 167, Failed: 0`
- full remote service test run on `live` after merge:
  - `dotnet test RdtClient.Service.Test/RdtClient.Service.Test.csproj`
  - result: `Passed: 170, Failed: 0`
- live deployment using `rdtclient-stage-release-overlay`
  - used `--backup-root /var/backups/rdtclient` so staging stayed off `/mnt/media`
  - pre-deploy live backup: `/var/backups/rdtclient/opt-rdtc-pre-deleteonerror-20260514165239`
- live verification after restart:
  - `TaskRunner` ticks every second
  - the tracked hash kept the same `Completed` value across several ticks instead of being refreshed

This confirms the timestamp reset loop has stopped in the live service.

## How To Test yourself

1. Configure `Delete download when in error` to a non-zero value.
2. Add or identify a torrent that is still in queued state but fails before provider add, such as `Could not add to provider: Infringing file`.
3. Confirm the torrent row has:
   - `RdId = null`
   - `RdAdded = null`
   - `RdStatus = Queued`
   - `Error` populated
   - `Completed` populated
4. Wait for at least one runner tick and verify `Completed` does not keep changing.
5. After `DeleteOnError` minutes elapse, verify the torrent is removed automatically.

That should be it 🙏
