### PR TITLE
feat(usenet): improve NZB status messages and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a web interface to manage your torrents on Real-Debrid, AllDebrid, Premiumize, TorBox or DebridLink. It supports the following features:
 
 - Add new torrents through magnets or files
-- Add usenet downloads through NZB files (TorBox only)
+- Add usenet downloads through NZB files (TorBox and Premiumize only)
 - Download all files from Real-Debrid, AllDebrid, Premiumize or TorBox to your local machine automatically
 - Unpack all files when finished downloading
 - Implements a fake qBittorrent API so you can hook up other applications like Sonarr, Radarr or Couchpotato.
@@ -166,7 +166,9 @@ It has the following options:
 
 ### Connecting Sonarr/Radarr
 
-RdtClient emulates the qBittorrent web protocol and allow applications to use those APIs. This way you can use Sonarr and Radarr to download directly from RealDebrid.
+RdtClient emulates the qBittorrent web protocol and allows applications to use those APIs. This way you can use Sonarr and Radarr to download directly from RealDebrid.
+
+#### Torrents
 
 1. Login to Sonarr or Radarr and click `Settings`.
 1. Go to the `Download Client` tab and click the plus to add.
@@ -182,6 +184,24 @@ RdtClient emulates the qBittorrent web protocol and allow applications to use th
 When downloading files it will append the `category` setting in the Sonarr/Radarr Download Client setting. For example if your Remote Path setting is set to `C:\Downloads` and your Sonarr Download Client setting `category` is set to `sonarr` files will be downloaded to `C:\Downloads\sonarr`.
 
 Notice: the progress and ETA reported in Sonarr's Activity tab will not be accurate, but it will report the torrent as completed so it can be processed after it is done downloading.
+
+#### Usenet/NZB
+
+RdtClient also emulates part of the SABnzbd API so Sonarr and Radarr can add NZB downloads. This requires a provider that supports Usenet/NZB downloads, currently TorBox or Premiumize.
+
+1. Login to Sonarr or Radarr and click `Settings`.
+1. Go to the `Download Client` tab and click the plus to add.
+1. Click `SABnzbd` in the list.
+1. Enter the IP or hostname of RdtClient in the `Host` field.
+1. Enter `6500` in the `Port` field.
+1. Enable `Use SSL` only if you access RdtClient through HTTPS.
+1. Leave `URL Base` empty unless RdtClient is configured with a `BasePath`, for example `/rdt`.
+1. If RdtClient authentication is enabled, leave `API Key` empty and enter your RdtClient username and password.
+1. If RdtClient authentication is disabled, enter any value in `API Key`, for example `rdtclient`, and leave username/password empty.
+1. Set the category to `sonarr` for Sonarr or `radarr` for Radarr.
+1. Hit `Test` and then `Save` if all is well.
+
+When importing completed NZB downloads, Sonarr/Radarr must be able to access the path reported by RdtClient. In Docker setups this may require a Remote Path Mapping from the RdtClient download path to the path mounted inside Sonarr/Radarr.
 
 ### Running within a folder
 

--- a/client/src/app/torrent-status.pipe.ts
+++ b/client/src/app/torrent-status.pipe.ts
@@ -98,6 +98,8 @@ export function getTorrentStatus(torrent: Torrent): string {
     return 'Finished';
   }
 
+  const prefix = torrent.type === 1 ? 'NZB' : 'Torrent';
+
   switch (torrent.rdStatus) {
     case RealDebridStatus.Queued:
       return 'Not Yet Added to Provider';
@@ -106,17 +108,17 @@ export function getTorrentStatus(torrent: Torrent): string {
         return 'Torrent stalled';
       }
 
-      return `Torrent downloading (${torrent.rdProgress}% - ${fileSizePipe.transform(torrent.rdSpeed, 'filesize') as string}/s)`;
+      return `${prefix} downloading (${torrent.rdProgress}% - ${fileSizePipe.transform(torrent.rdSpeed, 'filesize') as string}/s)`;
     case RealDebridStatus.Processing:
-      return 'Torrent processing';
+      return `${prefix} processing`;
     case RealDebridStatus.WaitingForFileSelection:
-      return 'Torrent waiting for file selection';
+      return `${prefix} waiting for file selection`;
     case RealDebridStatus.Error:
-      return `Torrent error: ${torrent.rdStatusRaw}`;
+      return `${prefix} error: ${torrent.rdStatusRaw}`;
     case RealDebridStatus.Finished:
-      return 'Torrent finished, waiting for download links';
+      return `${prefix} finished, waiting for download links`;
     case RealDebridStatus.Uploading:
-      return 'Torrent uploading';
+      return `${prefix} uploading`;
     default:
       return 'Unknown status';
   }

--- a/server/RdtClient.Service/Helpers/TorrentDtoMapper.cs
+++ b/server/RdtClient.Service/Helpers/TorrentDtoMapper.cs
@@ -214,16 +214,18 @@ public static class TorrentDtoMapper
             return "Finished";
         }
 
+        var prefix = torrent.Type == DownloadType.Nzb ? "NZB" : "Torrent";
+
         return torrent.RdStatus switch
         {
             TorrentStatus.Queued => "Not Yet Added to Provider",
             TorrentStatus.Downloading when torrent.RdSeeders < 1 && torrent.Type != DownloadType.Nzb => "Torrent stalled",
-            TorrentStatus.Downloading => $"Torrent downloading ({torrent.RdProgress}% - {FileSizeHelper.FormatSize(torrent.RdSpeed)}/s)",
-            TorrentStatus.Processing => "Torrent processing",
-            TorrentStatus.WaitingForFileSelection => "Torrent waiting for file selection",
-            TorrentStatus.Error => $"Torrent error: {torrent.RdStatusRaw}",
-            TorrentStatus.Finished => "Torrent finished, waiting for download links",
-            TorrentStatus.Uploading => "Torrent uploading",
+            TorrentStatus.Downloading => $"{prefix} downloading ({torrent.RdProgress}% - {FileSizeHelper.FormatSize(torrent.RdSpeed)}/s)",
+            TorrentStatus.Processing => $"{prefix} processing",
+            TorrentStatus.WaitingForFileSelection => $"{prefix} waiting for file selection",
+            TorrentStatus.Error => $"{prefix} error: {torrent.RdStatusRaw}",
+            TorrentStatus.Finished => $"{prefix} finished, waiting for download links",
+            TorrentStatus.Uploading => $"{prefix} uploading",
             _ => "Unknown status"
         };
     }


### PR DESCRIPTION
Follow-up to https://github.com/rogerfar/rdt-client/pull/974
- Update README.md to include Premiumize as a Usenet provider
- Add documentation for Sonarr/Radarr SABnzbd connection
- Update status messages to use 'NZB' instead of 'Torrent' for Usenet downloads in frontend and backend