### PR TITLE
Update TorBox.NET to 1.8.1

### DIFF
--- a/server/RdtClient.Service.Test/RdtClient.Service.Test.csproj
+++ b/server/RdtClient.Service.Test/RdtClient.Service.Test.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1" />
-        <PackageReference Include="TorBox.NET" Version="1.7.0" />
+        <PackageReference Include="TorBox.NET" Version="1.8.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/server/RdtClient.Service.Test/RdtClient.Service.Test.csproj
+++ b/server/RdtClient.Service.Test/RdtClient.Service.Test.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1" />
-        <PackageReference Include="TorBox.NET" Version="1.8.0" />
+        <PackageReference Include="TorBox.NET" Version="1.8.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/server/RdtClient.Service.Test/Services/TorrentClients/TorBoxDebridClientTest.cs
+++ b/server/RdtClient.Service.Test/Services/TorrentClients/TorBoxDebridClientTest.cs
@@ -383,7 +383,7 @@ public class TorBoxDebridClientTest
         torBoxClientMock.Setup(m => m.Torrents).Returns(torrentsApiMock.Object);
         clientMock.Protected().Setup<ITorBoxNetClient>("GetClient", ItExpr.IsAny<String>()).Returns(torBoxClientMock.Object);
 
-        torrentsApiMock.Setup(m => m.GetHashInfoAsync("test-hash", true, It.IsAny<CancellationToken>()))
+        torrentsApiMock.Setup(m => m.GetHashInfoAsync("test-hash", true, 1000, It.IsAny<CancellationToken>()))
                        .ReturnsAsync(new TorrentInfoResult
                        {
                            Id = 12345
@@ -434,7 +434,7 @@ public class TorBoxDebridClientTest
         torBoxClientMock.Setup(m => m.Torrents).Returns(torrentsApiMock.Object);
         clientMock.Protected().Setup<ITorBoxNetClient>("GetClient", ItExpr.IsAny<String>()).Returns(torBoxClientMock.Object);
 
-        torrentsApiMock.Setup(m => m.GetHashInfoAsync("test-hash", true, It.IsAny<CancellationToken>()))
+        torrentsApiMock.Setup(m => m.GetHashInfoAsync("test-hash", true, 1000, It.IsAny<CancellationToken>()))
                        .ReturnsAsync(new TorrentInfoResult
                        {
                            Id = 12345
@@ -544,7 +544,7 @@ public class TorBoxDebridClientTest
         torBoxClientMock.Setup(m => m.Usenet).Returns(usenetApiMock.Object);
         clientMock.Protected().Setup<ITorBoxNetClient>("GetClient", ItExpr.IsAny<String>()).Returns(torBoxClientMock.Object);
 
-        usenetApiMock.Setup(m => m.GetCurrentAsync(true, It.IsAny<CancellationToken>()))
+        usenetApiMock.Setup(m => m.GetCurrentAsync(true, 1000, It.IsAny<CancellationToken>()))
                      .ReturnsAsync(new List<UsenetInfoResult>
                      {
                          new()

--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Synology.Api.Client" Version="[0.3.93]" />
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1" />
-    <PackageReference Include="TorBox.NET" Version="1.7.0" />
+    <PackageReference Include="TorBox.NET" Version="1.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Synology.Api.Client" Version="[0.3.93]" />
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1" />
-    <PackageReference Include="TorBox.NET" Version="1.8.0" />
+    <PackageReference Include="TorBox.NET" Version="1.8.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This update just adds the error code into the exception message so its more clear from the logs what the error is from.

the build error from ci is because it hadnt been indexed on nuget yet, it has been now.