### PR TITLE
[TorBox] Handle rate limits/database errors for unrestricted links with download delays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ server/RdtClient.Web/appsettings.Development.json
 data
 Dockerfile.dev
 test.bat
+.DS_Store

--- a/server/RdtClient.Data/Data/DownloadData.cs
+++ b/server/RdtClient.Data/Data/DownloadData.cs
@@ -273,7 +273,7 @@ public class DownloadData(DataContext dataContext, ILogger<DownloadData>? logger
         await dataContext.SaveChangesAsync();
     }
 
-    public async Task Reset(Guid downloadId)
+    public async Task Reset(Guid downloadId, DateTimeOffset? downloadQueued = null)
     {
         var dbDownload = await dataContext.Downloads
                                           .FirstOrDefaultAsync(m => m.DownloadId == downloadId)
@@ -282,7 +282,7 @@ public class DownloadData(DataContext dataContext, ILogger<DownloadData>? logger
         dbDownload.RetryCount = 0;
         dbDownload.Link = null;
         dbDownload.Added = DateTimeOffset.UtcNow;
-        dbDownload.DownloadQueued = DateTimeOffset.UtcNow;
+        dbDownload.DownloadQueued = downloadQueued ?? DateTimeOffset.UtcNow;
         dbDownload.DownloadStarted = null;
         dbDownload.DownloadFinished = null;
         dbDownload.UnpackingQueued = null;

--- a/server/RdtClient.Service.Test/RdtClient.Service.Test.csproj
+++ b/server/RdtClient.Service.Test/RdtClient.Service.Test.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1" />
-        <PackageReference Include="TorBox.NET" Version="1.8.1" />
+        <PackageReference Include="TorBox.NET" Version="2.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>
@@ -35,12 +35,6 @@
 
     <ItemGroup>
       <ProjectReference Include="..\RdtClient.Service\RdtClient.Service.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="TorBoxNET">
-        <HintPath>..\..\..\torbox-net\TorBoxNET\bin\Release\netstandard2.0\TorBoxNET.dll</HintPath>
-      </Reference>
     </ItemGroup>
 
 </Project>

--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Synology.Api.Client" Version="[0.3.93]" />
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1" />
-    <PackageReference Include="TorBox.NET" Version="1.8.1" />
+    <PackageReference Include="TorBox.NET" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/server/RdtClient.Service/Services/DebridClients/TorBoxDebridClient.cs
+++ b/server/RdtClient.Service/Services/DebridClients/TorBoxDebridClient.cs
@@ -69,7 +69,10 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
         return await HandleAddTorrentErrors(async asQueued =>
         {
             var user = await GetClient().User.GetAsync(true);
-            var result = await GetClient(DiConfig.TORBOX_CLIENT_SLOW).Torrents.AddMagnetAsync(magnetLink, user.Data?.Settings?.SeedTorrents ?? 3, as_queued: asQueued);
+            var result = await GetClient(DiConfig.TORBOX_CLIENT_SLOW).Torrents.AddMagnetAsync(magnetLink,
+                                                                                               user.Data?.Settings?.SeedTorrents ?? 3,
+                                                                                               allowZip: Settings.Get.Provider.PreferZippedDownloads,
+                                                                                               as_queued: asQueued);
 
             return result.Data!.Hash!;
         });
@@ -80,7 +83,10 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
         return await HandleAddTorrentErrors(async asQueued =>
         {
             var user = await GetClient().User.GetAsync(true);
-            var result = await GetClient(DiConfig.TORBOX_CLIENT_SLOW).Torrents.AddFileAsync(bytes, user.Data?.Settings?.SeedTorrents ?? 3, as_queued: asQueued);
+            var result = await GetClient(DiConfig.TORBOX_CLIENT_SLOW).Torrents.AddFileAsync(bytes,
+                                                                                             user.Data?.Settings?.SeedTorrents ?? 3,
+                                                                                             allowZip: Settings.Get.Provider.PreferZippedDownloads,
+                                                                                             as_queued: asQueued);
 
             return result.Data!.Hash!;
         });
@@ -372,7 +378,7 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
             }
 
             var httpClient = httpClientFactory.CreateClient(clientId);
-            var torBoxNetClient = new TorBoxNetClient(null, httpClient);
+            var torBoxNetClient = new TorBoxNetClient(null, httpClient, retryCount: 5);
             torBoxNetClient.UseApiAuthentication(apiKey);
 
             // Get the server time to fix up the timezones on results
@@ -513,7 +519,7 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
         {
             throw rateLimitException;
         }
-        catch (TorBoxException ex) when ("active_limit".Equals(ex.Error, StringComparison.OrdinalIgnoreCase))
+        catch (TorBoxException ex) when (IsRateLimit(ex))
         {
             coordinator.UpdateCooldown(TorBoxApiHost, TimeSpan.FromMinutes(2));
 
@@ -541,7 +547,7 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
         {
             throw rateLimitException;
         }
-        catch (TorBoxException ex) when ("active_limit".Equals(ex.Error, StringComparison.OrdinalIgnoreCase))
+        catch (TorBoxException ex) when (IsRateLimit(ex))
         {
             coordinator.UpdateCooldown(TorBoxApiHost, TimeSpan.FromMinutes(2));
 
@@ -558,6 +564,12 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
     private async Task<String> HandleAddTorrentErrors(Func<Boolean, Task<String>> action)
     {
         return await HandleErrors(() => action(false));
+    }
+
+    private static Boolean IsRateLimit(TorBoxException exception)
+    {
+        return exception.Error.Equals("RATE_LIMIT", StringComparison.OrdinalIgnoreCase)
+               || exception.Error.Equals("ACTIVE_LIMIT", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<String> HandleAddUsenetErrors(Func<Boolean, Task<String>> action)

--- a/server/RdtClient.Service/Services/Downloads.cs
+++ b/server/RdtClient.Service/Services/Downloads.cs
@@ -86,8 +86,8 @@ public class Downloads(DownloadData downloadData) : IDownloads
         await downloadData.DeleteForTorrent(torrentId);
     }
 
-    public async Task Reset(Guid downloadId)
+    public async Task Reset(Guid downloadId, DateTimeOffset? downloadQueued = null)
     {
-        await downloadData.Reset(downloadId);
+        await downloadData.Reset(downloadId, downloadQueued);
     }
 }

--- a/server/RdtClient.Service/Services/IDownloads.cs
+++ b/server/RdtClient.Service/Services/IDownloads.cs
@@ -21,5 +21,5 @@ public interface IDownloads
     Task UpdateRetryCount(Guid downloadId, Int32 retryCount);
     Task UpdateRemoteId(Guid downloadId, String remoteId);
     Task DeleteForTorrent(Guid torrentId);
-    Task Reset(Guid downloadId);
+    Task Reset(Guid downloadId, DateTimeOffset? downloadQueued = null);
 }

--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -477,7 +477,11 @@ public class TorrentRunner(
             {
                 // Check if there are any downloads that are queued and can be started.
                 var queuedDownloads = torrent.Downloads
-                                             .Where(m => m.Completed == null && m.DownloadQueued != null && m.DownloadStarted == null && m.Error == null)
+                                             .Where(m => m.Completed == null
+                                                         && m.DownloadQueued != null
+                                                         && m.DownloadQueued <= DateTimeOffset.UtcNow
+                                                         && m.DownloadStarted == null
+                                                         && m.Error == null)
                                              .OrderBy(m => m.DownloadQueued)
                                              .ToList();
 
@@ -528,10 +532,24 @@ public class TorrentRunner(
                     {
                         logger.LogError(ex, "Cannot unrestrict link: {ex.Message}", ex.Message);
 
-                        await downloads.UpdateError(download.DownloadId, ex.Message);
-                        await downloads.UpdateCompleted(download.DownloadId, DateTimeOffset.UtcNow);
-                        download.Error = ex.Message;
-                        download.Completed = DateTimeOffset.UtcNow;
+                        if (download.RetryCount < torrent.DownloadRetryAttempts)
+                        {
+                            var retryCount = download.RetryCount + 1;
+                            var retryDelay = GetDownloadLinkRetryDelay(retryCount);
+                            var retryAt = DateTimeOffset.UtcNow.Add(retryDelay);
+
+                            Log($"Retrying download link generation {retryCount}/{torrent.DownloadRetryAttempts} at {retryAt:u}", download, torrent);
+
+                            await downloads.Reset(download.DownloadId, retryAt);
+                            await downloads.UpdateRetryCount(download.DownloadId, retryCount);
+                        }
+                        else
+                        {
+                            await downloads.UpdateError(download.DownloadId, ex.Message);
+                            await downloads.UpdateCompleted(download.DownloadId, DateTimeOffset.UtcNow);
+                            download.Error = ex.Message;
+                            download.Completed = DateTimeOffset.UtcNow;
+                        }
 
                         return;
                     }
@@ -780,6 +798,19 @@ public class TorrentRunner(
             NextDequeueTime = nextDequeueTime,
             SecondsRemaining = secondsRemaining
         });
+    }
+
+    private static TimeSpan GetDownloadLinkRetryDelay(Int32 retryCount)
+    {
+        var seconds = retryCount switch
+        {
+            <= 1 => 15,
+            2 => 30,
+            3 => 60,
+            _ => 120
+        };
+
+        return TimeSpan.FromSeconds(seconds);
     }
 
     private void Log(String message, Download? download, Torrent? torrent)


### PR DESCRIPTION
Fixes issues with TorBox downloads (DATABASE_ERROR/rate limiting on unrestricting links) by adding a delay to retrying unrestricting links. This should in theory (and from my testing of about 300 torrents) cause all torrents that are cached and are actually available to download on TorBox to work in rdtclient. This was the best way I could think of to deal with the unrestrict issues, but if you have a better idea I am happy to make changes.

Also bumps TorBox.NET to 2.0.0.

Related to #971 

Unrelated to these changes here, but at some point `add_only_if_cached` was added to the add torrents endpoints, so at some point ill send another PR to make it so that the `Only download available files on debrid provider` button actually does something when using TorBox.