### PR TITLE
[TorBox] fix: remove usage of GetHashInfoAsync

### DIFF
--- a/server/RdtClient.Service.Test/RdtClient.Service.Test.csproj
+++ b/server/RdtClient.Service.Test/RdtClient.Service.Test.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1" />
-        <PackageReference Include="TorBox.NET" Version="2.0.0" />
+        <PackageReference Include="TorBox.NET" Version="2.1.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/server/RdtClient.Service.Test/Services/TorrentClients/TorBoxDebridClientTest.cs
+++ b/server/RdtClient.Service.Test/Services/TorrentClients/TorBoxDebridClientTest.cs
@@ -44,6 +44,7 @@ public class TorBoxDebridClientTest
         {
             new()
             {
+                Id = 12345,
                 Hash = "hash1",
                 Name = "torrent1",
                 Size = 1000,
@@ -76,7 +77,7 @@ public class TorBoxDebridClientTest
         // Assert
         Assert.Equal(2, result.Count);
 
-        var torrentResult = result.FirstOrDefault(r => r.Id == "hash1");
+        var torrentResult = result.FirstOrDefault(r => r.Id == "12345");
         Assert.NotNull(torrentResult);
         Assert.Equal(DownloadType.Torrent, torrentResult.Type);
 
@@ -198,12 +199,12 @@ public class TorBoxDebridClientTest
     }
 
     [Fact]
-    public async Task Delete_CallsTorrentsControl_WhenTypeIsTorrent()
+    public async Task Delete_CallsTorrentsControlById_WhenTypeIsTorrent()
     {
         // Arrange
         var torrent = new Torrent
         {
-            RdId = "torrent-id",
+            RdId = "12345",
             Type = DownloadType.Torrent
         };
 
@@ -218,7 +219,7 @@ public class TorBoxDebridClientTest
         await clientMock.Object.Delete(torrent);
 
         // Assert
-        torrentsApiMock.Verify(m => m.ControlAsync("torrent-id", "delete", It.IsAny<CancellationToken>()), Times.Once);
+        torrentsApiMock.Verify(m => m.ControlByIdAsync(12345, "delete", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -373,6 +374,7 @@ public class TorBoxDebridClientTest
         var torrent = new Torrent
         {
             Hash = "test-hash",
+            RdId = "12345",
             RdFiles = JsonConvert.SerializeObject(files)
         };
 
@@ -382,12 +384,6 @@ public class TorBoxDebridClientTest
 
         torBoxClientMock.Setup(m => m.Torrents).Returns(torrentsApiMock.Object);
         clientMock.Protected().Setup<ITorBoxNetClient>("GetClient", ItExpr.IsAny<String>()).Returns(torBoxClientMock.Object);
-
-        torrentsApiMock.Setup(m => m.GetHashInfoAsync("test-hash", true, 1000, It.IsAny<CancellationToken>()))
-                       .ReturnsAsync(new TorrentInfoResult
-                       {
-                           Id = 12345
-                       });
 
         _fileFilterMock.Setup(m => m.IsDownloadable(torrent, It.IsAny<String>(), It.IsAny<Int64>())).Returns(true);
 
@@ -420,6 +416,7 @@ public class TorBoxDebridClientTest
         var torrent = new Torrent
         {
             Hash = "test-hash",
+            RdId = "12345",
             RdName = "TestTorrent",
             RdFiles = JsonConvert.SerializeObject(files),
             DownloadClient = DownloadClient.Aria2c
@@ -433,12 +430,6 @@ public class TorBoxDebridClientTest
 
         torBoxClientMock.Setup(m => m.Torrents).Returns(torrentsApiMock.Object);
         clientMock.Protected().Setup<ITorBoxNetClient>("GetClient", ItExpr.IsAny<String>()).Returns(torBoxClientMock.Object);
-
-        torrentsApiMock.Setup(m => m.GetHashInfoAsync("test-hash", true, 1000, It.IsAny<CancellationToken>()))
-                       .ReturnsAsync(new TorrentInfoResult
-                       {
-                           Id = 12345
-                       });
 
         _fileFilterMock.Setup(m => m.IsDownloadable(torrent, It.IsAny<String>(), It.IsAny<Int64>())).Returns(true);
 

--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Synology.Api.Client" Version="[0.3.93]" />
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1" />
-    <PackageReference Include="TorBox.NET" Version="2.0.0" />
+    <PackageReference Include="TorBox.NET" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/server/RdtClient.Service/Services/DebridClients/TorBoxDebridClient.cs
+++ b/server/RdtClient.Service/Services/DebridClients/TorBoxDebridClient.cs
@@ -74,7 +74,7 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
                                                                                                allowZip: Settings.Get.Provider.PreferZippedDownloads,
                                                                                                as_queued: asQueued);
 
-            return result.Data!.Hash!;
+            return result.Data?.TorrentId?.ToString() ?? throw new InvalidOperationException("TorBox API did not return torrent ID.");
         });
     }
 
@@ -88,7 +88,7 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
                                                                                              allowZip: Settings.Get.Provider.PreferZippedDownloads,
                                                                                              as_queued: asQueued);
 
-            return result.Data!.Hash!;
+            return result.Data?.TorrentId?.ToString() ?? throw new InvalidOperationException("TorBox API did not return torrent ID");
         });
     }
 
@@ -162,7 +162,7 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
             }
             else
             {
-                await GetClient().Torrents.ControlAsync(torrent.RdId, "delete");
+                await GetClient().Torrents.ControlByIdAsync(Int32.Parse(torrent.RdId), "delete");
             }
         });
     }
@@ -322,8 +322,12 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
         }
         else
         {
-            var torrentId = await HandleErrors(() => GetClient().Torrents.GetHashInfoAsync(torrent.Hash, true));
-            id = torrentId?.Id;
+            if (torrent.RdId == null)
+            {
+                return null;
+            }
+
+            id = Int32.Parse(torrent.RdId);
         }
 
         if (id == null)
@@ -447,7 +451,7 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
     {
         return new()
         {
-            Id = torrent.Hash,
+            Id = torrent.Id.ToString(),
             Filename = torrent.Name,
             OriginalFilename = torrent.Name,
             Hash = torrent.Hash,
@@ -602,7 +606,7 @@ public class TorBoxDebridClient(ILogger<TorBoxDebridClient> logger, IHttpClientF
             }
             else
             {
-                var result = await GetClient().Torrents.GetHashInfoAsync(id, true);
+                var result = await GetClient().Torrents.GetIdInfoAsync(Int32.Parse(id), true);
 
                 if (result != null)
                 {

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -662,6 +662,38 @@ public class Torrents(
             {
                 torrentsByRdId.TryGetValue(rdTorrent.Id, out var torrent);
 
+                // TorBox migration from storing torrent hash in RdId to torrent ids.
+                if (torrent == null
+                    && Settings.Get.Provider.Provider == Provider.TorBox
+                    && rdTorrent.Type == DownloadType.Torrent
+                    && !String.IsNullOrWhiteSpace(rdTorrent.Hash)
+                    && !String.IsNullOrWhiteSpace(rdTorrent.Id))
+                {
+                    torrent = torrents.FirstOrDefault(localTorrent => localTorrent is { Type: DownloadType.Torrent, ClientKind: null or Provider.TorBox }
+                                                                      && !String.IsNullOrWhiteSpace(localTorrent.Hash)
+                                                                      && !String.IsNullOrWhiteSpace(localTorrent.RdId)
+                                                                      && localTorrent.RdId.Equals(localTorrent.Hash, StringComparison.OrdinalIgnoreCase)
+                                                                      && localTorrent.Hash.Equals(rdTorrent.Hash, StringComparison.OrdinalIgnoreCase));
+
+                    if (torrent != null)
+                    {
+                        if (!String.IsNullOrWhiteSpace(torrent.RdId))
+                        {
+                            torrentsByRdId.Remove(torrent.RdId);
+                        }
+
+                        await torrentData.UpdateRdId(torrent, rdTorrent.Id);
+                        torrent.RdId = rdTorrent.Id;
+                        torrent.ClientKind = Provider.TorBox;
+                        torrentsByRdId[rdTorrent.Id] = torrent;
+
+                        logger.LogInformation("Migrated TorBox torrent RdId from hash to torrent id for {TorrentName} ({Hash}) -> {RdId}",
+                                              torrent.RdName ?? rdTorrent.Filename,
+                                              rdTorrent.Hash,
+                                              rdTorrent.Id);
+                    }
+                }
+
                 // Auto import torrents only torrents that have their files selected
                 if (torrent == null && Settings.Get.Provider.AutoImport)
                 {


### PR DESCRIPTION
Removes GetHashInfoAsync, and only uses the actual torrentId.

This was originally required as cachedtorrents endpoints used to use a different torrentId to the regular torrent endpoints for whatever reason, but luckily TorBox figured out a while ago that that was not a good idea and just combined them which means calling the API and filtering it by torrent hash to find the torrent id isn't needed anymore. This fixes #971, as it wont use the old torrentId anymore since it'll get the new one when the torrent is made. This should hopefully also reduce rate limiting a little bit.