### PR TITLE
delete from provider when torrent lifetime has passed

### DIFF
--- a/client/src/app/add-new-torrent/add-new-torrent.component.html
+++ b/client/src/app/add-new-torrent/add-new-torrent.component.html
@@ -285,8 +285,8 @@
         <input class="input" type="number" max="100000" min="0" step="1" [(ngModel)]="torrentLifetime" />
       </div>
       <p class="help">
-        The maximum lifetime of a download in minutes. When this time has passed, mark it as error. If the download is
-        completed, the lifetime setting will not apply. 0 to disable.
+        The maximum lifetime of a download in minutes. When this time has passed, mark it as error and delete it from
+        the provider. If the download is completed, the lifetime setting will not apply. 0 to disable.
       </p>
     </div>
   </div>

--- a/client/src/app/torrent-table/torrent-table.component.html
+++ b/client/src/app/torrent-table/torrent-table.component.html
@@ -331,8 +331,9 @@
           />
         </div>
         <p class="help">
-          The maximum lifetime of a torrent in minutes. When this time has passed, mark the torrent as error. If the
-          torrent is completed and has downloads, the lifetime setting will not apply. 0 to disable.
+          The maximum lifetime of a torrent in minutes. When this time has passed, mark the torrent as error and delete
+          it from the provider. If the torrent is completed and has downloads, the lifetime setting will not apply. 0 to
+          disable.
         </p>
       </div>
 

--- a/client/src/app/torrent/torrent.component.html
+++ b/client/src/app/torrent/torrent.component.html
@@ -678,8 +678,9 @@
           />
         </div>
         <p class="help">
-          The maximum lifetime of a torrent in minutes. When this time has passed, mark the torrent as error. If the
-          torrent is completed and has downloads, the lifetime setting will not apply. 0 to disable.
+          The maximum lifetime of a torrent in minutes. When this time has passed, mark the torrent as error and delete
+          it from the provider. If the torrent is completed and has downloads, the lifetime setting will not apply. 0 to
+          disable.
         </p>
       </div>
     </section>

--- a/server/RdtClient.Data/Models/Internal/DbSettings.cs
+++ b/server/RdtClient.Data/Models/Internal/DbSettings.cs
@@ -321,7 +321,7 @@ public class DbSettingsDefaults
     public Int32 DeleteOnError { get; set; } = 0;
 
     [DisplayName("Torrent maximum lifetime")]
-    [Description("The maximum lifetime of a torrent in minutes. When this time has passed, mark the torrent as error. If the torrent is completed and has downloads, the lifetime setting will not apply. 0 to disable.")]
+    [Description("The maximum lifetime of a torrent in minutes. When this time has passed, mark the torrent as error and delete it from the provider. If the torrent is completed and has downloads, the lifetime setting will not apply. 0 to disable.")]
     public Int32 TorrentLifetime { get; set; } = 0;
 
     [DisplayName("Priority")]

--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -360,10 +360,18 @@ public class TorrentRunner(
                 continue;
             }
 
-            Log($"Torrent has reached its {torrent.Lifetime} minutes lifetime, marking as error", torrent);
+            var error = $"Torrent lifetime of {torrent.Lifetime} minutes reached";
+
+            Log($"{error}, marking as error and deleting from provider", torrent);
 
             await torrents.UpdateRetry(torrent.TorrentId, null, torrent.TorrentRetryAttempts);
-            await torrents.UpdateComplete(torrent.TorrentId, $"Torrent lifetime of {torrent.Lifetime} minutes reached", DateTimeOffset.UtcNow, false);
+            await torrents.Delete(torrent.TorrentId, false, true, false);
+            await torrents.UpdateComplete(torrent.TorrentId, error, DateTimeOffset.UtcNow, false);
+
+            torrent.Retry = null;
+            torrent.RetryCount = torrent.TorrentRetryAttempts;
+            torrent.Completed = DateTimeOffset.UtcNow;
+            torrent.Error = error;
         }
 
         // Process torrents in DebridQueue
@@ -382,7 +390,9 @@ public class TorrentRunner(
             }
             else
             {
-                var downloadingTorrentsCount = allTorrents.Count(m => m.RdStatus is not (TorrentStatus.Queued or TorrentStatus.Finished or TorrentStatus.Error));
+                var downloadingTorrentsCount = allTorrents.Count(m => m.Completed == null
+                                                                      && m.Error == null
+                                                                      && m.RdStatus is not (TorrentStatus.Queued or TorrentStatus.Finished or TorrentStatus.Error));
 
                 var maxParallelDownloads = settings.Current.Provider.MaxParallelDownloads;
 


### PR DESCRIPTION
This makes torrents be also deleted from the provider when the torrent lifetime has passed.

This will fix #987.