### PR TITLE
Add dev container setup for streamlined development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/dotnet:2-10.0-noble
+
+ARG NODE_MAJOR=22
+ARG ANGULAR_CLI_VERSION=21
+
+RUN curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs sqlite3 \
+    && npm install -g "@angular/cli@^${ANGULAR_CLI_VERSION}" \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /data/db /data/downloads \
+    && chown -R vscode:vscode /data

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{
+  "name": "rdt-client",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "NODE_MAJOR": "22"
+    }
+  },
+  "remoteUser": "vscode",
+  "runArgs": ["--init"],
+  "containerEnv": {
+    "ASPNETCORE_ENVIRONMENT": "Development",
+    "BASE_PATH": "",
+    "DOTNET_USE_POLLING_FILE_WATCHER": "1",
+    "CHOKIDAR_USEPOLLING": "true"
+  },
+  "forwardPorts": [4200, 6500],
+  "portsAttributes": {
+    "4200": {
+      "label": "Angular client",
+      "onAutoForward": "notify"
+    },
+    "6500": {
+      "label": "RdtClient backend",
+      "onAutoForward": "silent"
+    }
+  },
+  "mounts": [
+    "source=rdtclient-data-db,target=/data/db,type=volume",
+    "source=rdtclient-data-downloads,target=/data/downloads,type=volume",
+    "source=rdtclient-nuget,target=/home/vscode/.nuget,type=volume",
+    "source=rdtclient-npm-cache,target=/home/vscode/.npm,type=volume"
+  ],
+  "postCreateCommand": "/bin/bash .devcontainer/post-create.sh",
+  "postStartCommand": "/bin/bash .devcontainer/post-start.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit",
+        "Angular.ng-template",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "dotnet.defaultSolution": "server/RdtClient.sln",
+        "terminal.integrated.defaultProfile.linux": "zsh"
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sudo install -d -m 0775 -o vscode -g vscode \
+  /data/db \
+  /data/downloads \
+  /home/vscode/.nuget \
+  /home/vscode/.nuget/NuGet \
+  /home/vscode/.nuget/packages \
+  /home/vscode/.npm
+
+sudo chown -R vscode:vscode /data /home/vscode/.nuget /home/vscode/.npm
+
+dotnet restore server/RdtClient.sln
+npm install --prefix client

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sudo install -d -m 0775 -o vscode -g vscode \
+  /data/db \
+  /data/downloads \
+  /home/vscode/.nuget \
+  /home/vscode/.nuget/NuGet \
+  /home/vscode/.nuget/packages \
+  /home/vscode/.npm
+
+sudo chown -R vscode:vscode /data /home/vscode/.nuget /home/vscode/.npm

--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ By default the application runs in the root of your hosted address (i.e. https:/
 - Visual Studio 2025
 - (optional) Resharper
 
+### Dev Container
+
+The repository includes a dev container under `.devcontainer/` for the split development workflow used by this project.
+
+It installs .NET 10 and Node 22, forwards ports `4200` and `6500`, and persists `/data/db` and `/data/downloads` in named volumes so the local SQLite database, logs, and downloads survive container rebuilds.
+
+1. Open the repository in the dev container.
+1. In one terminal run `dotnet watch run --project server/RdtClient.Web`.
+1. In another terminal run `cd client && npm start`.
+1. Open `http://localhost:4200`. The Angular dev server proxies `/Api` and `/hub` to the backend running on `6500`.
+
 1. Open the client folder project in VS Code and run `npm install`.
 1. To debug run `ng serve`, to build run `ng build -c production`.
 1. Open the Visual Studio 2025 project `RdtClient.sln` and `Publish` the `RdtClient.Web` to the given `PublishFolder` target.


### PR DESCRIPTION
I've found this helpful to prevent importing specific dotnet and angular dependencies into my host. Others may as well. 

Container is based off a typical dotnet 10 environment, with angular dependencies added to the image.

Includes Dockerfile, scripts for post-start and post-create configuration, and README instructions for using the environment with .NET and Angular.Includes Dockerfile, scripts for post-start and post-create configuration, and README instructions for using the environment with .NET and Angular.

Tested with Rider, should work in VSCode too.