### PR TITLE
fix: Disable shared cache on SQLITE, reduces SQLITE locking errors.

### DIFF
--- a/server/RdtClient.Data/DiConfig.cs
+++ b/server/RdtClient.Data/DiConfig.cs
@@ -14,7 +14,7 @@ public static class DiConfig
             throw new("Invalid database path found in appSettings");
         }
 
-        var connectionString = $"Data Source={appSettings.Database.Path};Cache=Shared;Pooling=True;Command Timeout=30";
+        var connectionString = $"Data Source={appSettings.Database.Path};Cache=Private;Pooling=True;Command Timeout=30";
         services.AddDbContext<DataContext>(options => options.UseSqlite(connectionString));
 
         services.AddScoped<DownloadData>();


### PR DESCRIPTION
Per documentation by Sqlite and MS, using `Cache=Shared` is discouraged, especially in combination with WAL. WAL mode is supposed to be the better solution overall, and enabling shared cache changes table locking behaviour increasing errors seen from concurrent actions.

> [Microsoft.Data.Sqlite connection strings](https://learn.microsoft.com/en-us/dotnet/standard/data/sqlite/connection-strings)
> Relevant sections:
> 
> Cache: Shared means connections share a cache and “can change the behavior of transaction and table locking.”
> Example warning: Microsoft says mixing shared-cache mode and WAL is discouraged, and for optimal WAL performance you should remove Cache=Shared.


> [SQLite shared-cache mode](https://www.sqlite.org/sharedcache.html)
> Relevant sections:
> 
> “Use of shared-cache is discouraged”
> “Most use cases for shared-cache are better served by WAL mode”

Reading a bit on this, the only real clear use-case for `Cache=Shared` is when using in memory tables across multiple connections, as `Cache=Private` would result in multiple tables in that case (one per connection).