### PR TITLE
Fix/symlink downloader

### DIFF
--- a/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
@@ -1,4 +1,4 @@
-﻿using RdtClient.Data.Enums;
+using RdtClient.Data.Enums;
 using RdtClient.Service.Helpers;
 using Serilog;
 
@@ -6,8 +6,6 @@ namespace RdtClient.Service.Services.Downloaders;
 
 public class SymlinkDownloader(String uri, String destinationPath, String path, Provider? clientKind) : IDownloader
 {
-    private const Int32 MaxRetries = 10;
-
     private readonly CancellationTokenSource _cancellationToken = new();
 
     private readonly ILogger _logger = Log.ForContext<SymlinkDownloader>();
@@ -108,44 +106,32 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
 
                 potentialFilePaths = potentialFilePaths.Distinct().ToList();
 
-                for (var retryCount = 0; retryCount < MaxRetries; retryCount++)
+                _logger.Debug($"Searching {rcloneMountPath} for {fileName}...");
+
+                file = FindFile(rcloneMountPath, potentialFilePaths, fileName);
+
+                if (file == null && searchSubDirectories)
                 {
-                    DownloadProgress?.Invoke(this,
-                                             new()
-                                             {
-                                                 BytesDone = retryCount,
-                                                 BytesTotal = 10,
-                                                 Speed = 1
-                                             });
+                    var subDirectories = Directory.GetDirectories(rcloneMountPath, "*.*", SearchOption.TopDirectoryOnly);
 
-                    _logger.Debug($"Searching {rcloneMountPath} for {fileName} (attempt #{retryCount})...");
-
-                    file = FindFile(rcloneMountPath, potentialFilePaths, fileName);
-
-                    if (file == null && searchSubDirectories)
+                    foreach (var subDirectory in subDirectories)
                     {
-                        var subDirectories = Directory.GetDirectories(rcloneMountPath, "*.*", SearchOption.TopDirectoryOnly);
+                        file = FindFile(Path.Combine(rcloneMountPath, subDirectory), potentialFilePaths, fileName);
 
-                        foreach (var subDirectory in subDirectories)
+                        if (file != null)
                         {
-                            file = FindFile(Path.Combine(rcloneMountPath, subDirectory), potentialFilePaths, fileName);
-
-                            if (file != null)
-                            {
-                                break;
-                            }
+                            break;
                         }
                     }
-
-                    if (file == null)
-                    {
-                        await Task.Delay(1000 * retryCount);
-                    }
-                    else
-                    {
-                        break;
-                    }
                 }
+
+                DownloadProgress?.Invoke(this,
+                                         new()
+                                         {
+                                             BytesDone = 1,
+                                             BytesTotal = 1,
+                                             Speed = 0
+                                         });
             }
 
             if (file == null)
@@ -172,7 +158,7 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
 
             if (!result)
             {
-                throw new("Could not find file from rclone mount!");
+                throw new("Could not create symbolic link!");
             }
 
             DownloadComplete?.Invoke(this, new());
@@ -229,6 +215,12 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
     {
         try
         {
+            if (File.Exists(symlinkPath)) // Symlink already exists from a prior run.
+            {
+                _logger.Information($"Symbolic link already exists at {symlinkPath}");
+                return true;
+            }
+
             File.CreateSymbolicLink(symlinkPath, sourcePath);
 
             if (File.Exists(symlinkPath)) // Double-check that the link was created

--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.Json;
 using Aria2NET;
@@ -216,9 +216,15 @@ public class TorrentRunner(
 
                     if (download.RetryCount < download.Torrent.DownloadRetryAttempts)
                     {
-                        Log($"Retrying download", download, download.Torrent);
+                        var retryDelay = download.Torrent.DownloadClient == Data.Enums.DownloadClient.Symlink
+                                             ? TimeSpan.FromMinutes(1)
+                                             : TimeSpan.Zero;
 
-                        await downloads.Reset(downloadId);
+                        var retryAt = DateTimeOffset.UtcNow.Add(retryDelay);
+
+                        Log($"Retrying download at {retryAt:u}", download, download.Torrent);
+
+                        await downloads.Reset(downloadId, retryAt);
                         await downloads.UpdateRetryCount(downloadId, download.RetryCount + 1);
                     }
                     else


### PR DESCRIPTION
The symlink downloader had two issues causing my TorBox downloads to fail:

1. **Internal retry loop wasted time**: The downloader tried 10 times with increasing delays (up to 9 seconds), but the rclone CDN mount can take up to 15 minutes to refresh. Changed to single-shot search, letting TorrentRunner's retry mechanism handle the pacing.

2. **No cooldown between retries**: When the symlink search failed, TorrentRunner retried immediately with zero delay, hammering disk I/O and potentially hitting API rate limits. Added a 60-second delay between retry attempts using the existing DownloadRetryAttempts setting.

3. **Already-existing symlinks treated as errors**: If a symlink already existed from a prior run, File.CreateSymbolicLink threw "file already exists", causing the download to report failure. Now returns success gracefully.

Tested with TorBox provider using rclone mount and symlink generator.