### PR TITLE
feat: add Bezzad local IP binding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ It has the following options:
 - Parallel connections per download: This number indicates how many parallel it will use per download. This can increase speed, recommended is no more than 8.
 - Parallel chunks per download: This number indicates in how many chunks each download is split, recommended is no more than 8.
 - Connection Timeout: This number indicates the timeout in milliseconds before a download chunk times out. It will retry each chunk 5 times before completely failing.
+- Bind to specific IP: When enabled, the downloader binds outbound connections to the configured local IP address. Useful on hosts with multiple network interfaces.
+- Bind IP address: The local IP address to bind to. Must be an IP assigned to an active network adapter on this host.
 
 #### Aria2c downloader
 

--- a/server/RdtClient.Data/Models/Internal/DbSettings.cs
+++ b/server/RdtClient.Data/Models/Internal/DbSettings.cs
@@ -132,6 +132,14 @@ public class DbSettingsDownloadClient
     [Description("Address of a proxy server to download through (only used for the Bezzad Downloader).")]
     public String? ProxyServer { get; set; } = null;
 
+    [DisplayName("Bind to specific IP (Bezzad only)")]
+    [Description("When enabled, Bezzad will bind outbound connections to the IP address below.")]
+    public Boolean BindToSpecificIp { get; set; } = false;
+
+    [DisplayName("Bind IP address (Bezzad only)")]
+    [Description("Local IP address to bind Bezzad downloads to. Must be assigned to an active network adapter on this host.")]
+    public String? BindIpAddress { get; set; } = null;
+
     [DisplayName("Aria2c URL (only used for the Aria2c Downloader)")]
     [Description(@"This is the URL to your Aria2c instance. It must end in /jsonrpc. A common URL is
 http://127.0.0.1:6800/jsonrpc.")]

--- a/server/RdtClient.Service.Test/Helpers/BindIpAddressHelperTest.cs
+++ b/server/RdtClient.Service.Test/Helpers/BindIpAddressHelperTest.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using RdtClient.Service.Helpers;
+
+namespace RdtClient.Service.Test.Helpers;
+
+public class BindIpAddressHelperTest
+{
+    [Fact]
+    public void TryResolve_WhenDisabled_ReturnsNull()
+    {
+        // Act
+        var result = BindIpAddressHelper.TryResolve(false, "127.0.0.1");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-an-ip")]
+    public void TryResolve_WhenEnabledWithEmptyOrInvalid_ReturnsNull(String? configuredAddress)
+    {
+        // Act
+        var result = BindIpAddressHelper.TryResolve(true, configuredAddress);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryResolve_WhenEnabledWithNonLocalIp_ReturnsNull()
+    {
+        // Act
+        var result = BindIpAddressHelper.TryResolve(true, "8.8.8.8");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryResolve_WhenEnabledWithLoopback_ReturnsLoopback()
+    {
+        // Act
+        var result = BindIpAddressHelper.TryResolve(true, "127.0.0.1");
+
+        // Assert
+        Assert.Equal(IPAddress.Loopback, result);
+    }
+
+    [Fact]
+    public void TryResolve_WhenEnabledWithLocalInterfaceIp_ReturnsAddress()
+    {
+        // Arrange
+        var localIpAddress = GetFirstLocalIpv4Address();
+
+        if (localIpAddress == null)
+        {
+            return;
+        }
+
+        // Act
+        var result = BindIpAddressHelper.TryResolve(true, localIpAddress.ToString());
+
+        // Assert
+        Assert.Equal(localIpAddress, result);
+    }
+
+    [Fact]
+    public void IsLocalUnicastAddress_WithPublicIp_ReturnsFalse()
+    {
+        // Act
+        var result = BindIpAddressHelper.IsLocalUnicastAddress(IPAddress.Parse("8.8.8.8"));
+
+        // Assert
+        Assert.False(result);
+    }
+
+    private static IPAddress? GetFirstLocalIpv4Address()
+    {
+        foreach (var networkInterface in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (networkInterface.OperationalStatus != OperationalStatus.Up)
+            {
+                continue;
+            }
+
+            foreach (var unicast in networkInterface.GetIPProperties().UnicastAddresses)
+            {
+                if (unicast.Address.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(unicast.Address))
+                {
+                    return unicast.Address;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/server/RdtClient.Service/Helpers/BindIpAddressHelper.cs
+++ b/server/RdtClient.Service/Helpers/BindIpAddressHelper.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+
+namespace RdtClient.Service.Helpers;
+
+public static class BindIpAddressHelper
+{
+    public static IPAddress? TryResolve(Boolean bindToSpecificIp, String? configuredAddress)
+    {
+        if (!bindToSpecificIp)
+        {
+            return null;
+        }
+
+        if (String.IsNullOrWhiteSpace(configuredAddress))
+        {
+            return null;
+        }
+
+        if (!IPAddress.TryParse(configuredAddress, out var bindIpAddress))
+        {
+            return null;
+        }
+
+        if (!IsLocalUnicastAddress(bindIpAddress))
+        {
+            return null;
+        }
+
+        return bindIpAddress;
+    }
+
+    public static Boolean IsLocalUnicastAddress(IPAddress address)
+    {
+        foreach (var networkInterface in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (networkInterface.OperationalStatus != OperationalStatus.Up)
+            {
+                continue;
+            }
+
+            foreach (var unicast in networkInterface.GetIPProperties().UnicastAddresses)
+            {
+                if (unicast.Address.Equals(address))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/server/RdtClient.Service/Services/Downloaders/BezzadDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/BezzadDownloader.cs
@@ -1,31 +1,37 @@
-﻿using System.Net;
+using System.Net;
+using System.Net.Sockets;
 using Downloader;
+using RdtClient.Service.Helpers;
 using Serilog;
 
 namespace RdtClient.Service.Services.Downloaders;
 
 public class BezzadDownloader : IDownloader
 {
+    private const Int32 BindRetryDelayMilliseconds = 1000;
+
     private readonly DownloadConfiguration _downloadConfiguration;
-
     private readonly DownloadService _downloadService;
-
+    private readonly IDelayProvider _delayProvider;
     private readonly String _filePath;
-
     private readonly ILogger _logger;
     private readonly String _uri;
 
     private Boolean _finished;
 
     public BezzadDownloader(String uri, String filePath)
+        : this(uri, filePath, null)
+    {
+    }
+
+    internal BezzadDownloader(String uri, String filePath, IDelayProvider? delayProvider)
     {
         _logger = Log.ForContext<BezzadDownloader>();
         _logger.Debug($"Instantiated new Bezzad Downloader for URI {uri} to filePath {filePath}");
 
         _uri = uri;
         _filePath = filePath;
-
-        var settingProxyServer = Settings.Get.DownloadClient.ProxyServer;
+        _delayProvider = delayProvider ?? new DefaultDelayProvider();
 
         // For all options, see https://github.com/bezzad/Downloader
         _downloadConfiguration = new()
@@ -35,6 +41,7 @@ public class BezzadDownloader : IDownloader
             ClearPackageOnCompletionWithFailure = true,
             CheckDiskSizeBeforeDownload = false,
             MaximumMemoryBufferBytes = 1024 * 1024 * 10,
+            CustomHttpMessageHandlerFactory = CreateHttpMessageHandler,
             RequestConfiguration =
             {
                 Accept = "*/*",
@@ -47,11 +54,6 @@ public class BezzadDownloader : IDownloader
         };
 
         SetSettings();
-
-        if (!String.IsNullOrWhiteSpace(settingProxyServer))
-        {
-            _downloadConfiguration.RequestConfiguration.Proxy = new WebProxy(new Uri(settingProxyServer), false);
-        }
 
         _downloadService = new(_downloadConfiguration);
 
@@ -101,12 +103,8 @@ public class BezzadDownloader : IDownloader
     {
         _logger.Debug($"Starting download of {_uri}, writing to path: {_filePath}");
 
-        _ = Task.Run(async () =>
-        {
-            await _downloadService.DownloadFileTaskAsync(_uri, _filePath);
-        });
-
-        _ = Task.Run(StartTimer);
+        _ = RunDownloadAsync();
+        _ = StartTimer();
 
         return Task.FromResult(Guid.NewGuid().ToString());
     }
@@ -115,6 +113,7 @@ public class BezzadDownloader : IDownloader
     {
         _logger.Debug($"Cancelling download {_uri}");
 
+        _finished = true;
         _downloadService.CancelAsync();
 
         return Task.CompletedTask;
@@ -134,6 +133,152 @@ public class BezzadDownloader : IDownloader
         _downloadService.Resume();
 
         return Task.CompletedTask;
+    }
+
+    private SocketsHttpHandler CreateHttpMessageHandler()
+    {
+        var proxy = CreateProxy();
+
+        var handler = new SocketsHttpHandler
+        {
+            Proxy = proxy,
+            UseProxy = proxy != null
+        };
+
+        if (Settings.Get.DownloadClient.BindToSpecificIp)
+        {
+            handler.ConnectCallback = ConnectCallback;
+        }
+
+        return handler;
+    }
+
+    private async ValueTask<Stream> ConnectCallback(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var bindIpAddress = GetBindIpAddress();
+
+            if (bindIpAddress == null)
+            {
+                _logger.Warning("Bezzad bind-to-IP is enabled but the configured IP address is invalid or empty. Retrying.");
+                await _delayProvider.Delay(BindRetryDelayMilliseconds);
+                continue;
+            }
+
+            try
+            {
+                return await ConnectWithBindingAsync(context, bindIpAddress, cancellationToken);
+            }
+            catch (SocketException ex)
+            {
+                _logger.Warning(ex, "Unable to bind Bezzad download to IP {BindIpAddress} for {Uri}. Retrying.", bindIpAddress, _uri);
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.Warning(ex, "Unable to bind Bezzad download to IP {BindIpAddress} for {Uri}. Retrying.", bindIpAddress, _uri);
+            }
+
+            await _delayProvider.Delay(BindRetryDelayMilliseconds);
+        }
+    }
+
+    private static WebProxy? CreateProxy()
+    {
+        var settingProxyServer = Settings.Get.DownloadClient.ProxyServer;
+
+        if (String.IsNullOrWhiteSpace(settingProxyServer))
+        {
+            return null;
+        }
+
+        return new WebProxy(new Uri(settingProxyServer), false);
+    }
+
+    private async Task RunDownloadAsync()
+    {
+        try
+        {
+            await _downloadService.DownloadFileTaskAsync(_uri, _filePath);
+        }
+        catch (OperationCanceledException) when (_finished)
+        {
+        }
+        catch (Exception ex)
+        {
+            if (_finished)
+            {
+                return;
+            }
+
+            DownloadComplete?.Invoke(this,
+                                     new()
+                                     {
+                                         Error = ex.Message
+                                     });
+
+            _finished = true;
+        }
+    }
+
+    private async ValueTask<Stream> ConnectWithBindingAsync(SocketsHttpConnectionContext context, IPAddress bindIpAddress, CancellationToken cancellationToken)
+    {
+        var remoteAddresses = await Dns.GetHostAddressesAsync(context.DnsEndPoint.Host);
+
+        var compatibleRemoteAddresses = remoteAddresses.Where(m => m.AddressFamily == bindIpAddress.AddressFamily).ToArray();
+
+        if (compatibleRemoteAddresses.Length == 0)
+        {
+            throw new SocketException((Int32)SocketError.HostNotFound);
+        }
+
+        Exception? lastError = null;
+
+        foreach (var remoteAddress in compatibleRemoteAddresses)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                return await ConnectToRemoteAddressAsync(remoteAddress, context.DnsEndPoint.Port, bindIpAddress, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+        }
+
+        throw lastError ?? new HttpRequestException($"Unable to connect to {context.DnsEndPoint.Host}:{context.DnsEndPoint.Port}");
+    }
+
+    private static async ValueTask<Stream> ConnectToRemoteAddressAsync(IPAddress remoteAddress, Int32 remotePort, IPAddress? bindIpAddress, CancellationToken cancellationToken)
+    {
+        var socket = new Socket(remoteAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+        try
+        {
+            if (bindIpAddress != null)
+            {
+                socket.Bind(new IPEndPoint(bindIpAddress, 0));
+            }
+
+            await socket.ConnectAsync(new IPEndPoint(remoteAddress, remotePort), cancellationToken);
+
+            return new NetworkStream(socket, true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+
+    private IPAddress? GetBindIpAddress()
+    {
+        return BindIpAddressHelper.TryResolve(Settings.Get.DownloadClient.BindToSpecificIp,
+                                              Settings.Get.DownloadClient.BindIpAddress);
     }
 
     private void SetSettings()
@@ -174,7 +319,9 @@ public class BezzadDownloader : IDownloader
         _downloadConfiguration.ParallelDownload = settingParallelCount > 1;
         _downloadConfiguration.ParallelCount = settingParallelCount;
         _downloadConfiguration.BlockTimeout = settingDownloadTimeout;
-        _downloadConfiguration.HttpClientTimeout = settingDownloadTimeout;
+
+        // Bind-to-IP connect retries can run indefinitely; HttpClientTimeout must not cut them off.
+        _downloadConfiguration.HttpClientTimeout = Settings.Get.DownloadClient.BindToSpecificIp ? Int32.MaxValue : settingDownloadTimeout;
     }
 
     private async Task StartTimer()
@@ -189,6 +336,14 @@ public class BezzadDownloader : IDownloader
             }
 
             SetSettings();
+        }
+    }
+
+    private sealed class DefaultDelayProvider : IDelayProvider
+    {
+        public Task Delay(Int32 milliseconds)
+        {
+            return Task.Delay(milliseconds);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add Bezzad-only settings to bind downloads to a specific local IP
- Validate the configured IP against active local network adapters
- Use custom `ConnectCallback` only when binding is enabled
- Add unit tests and README documentation
## Why
On hosts with multiple active network interfaces, the OS chooses the default route for outbound traffic. That may not match what the user wants for large downloads.
This adds optional source-IP binding so Bezzad downloads can be pinned to a chosen interface — for example:
- Keep Ethernet free for low-latency or priority traffic (gaming, work, local services)
- Route bulk downloads over Wi-Fi where throughput matters more than latency
This is useful on laptops, desktops with Wi-Fi + Ethernet, and servers with multiple NICs/VLANs.