### PR TITLE
add file size validation check post download

### DIFF
--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -123,6 +123,29 @@ public static class DownloadHelper
         return FileHelper.RemoveInvalidFileNameChars(fileName);
     }
 
+    public static Int64? GetExpectedFileSize(Torrent torrent, Download download)
+    {
+        var fileName = GetFileName(download);
+
+        if (String.IsNullOrWhiteSpace(fileName))
+        {
+            return null;
+        }
+
+        var matchingTorrentFiles = torrent.Files
+                                          .Where(m => !String.IsNullOrWhiteSpace(m.Path) && m.Path.EndsWith(fileName))
+                                          .ToList();
+
+        if (matchingTorrentFiles.Count != 1)
+        {
+            return null;
+        }
+
+        var size = matchingTorrentFiles[0].Bytes;
+
+        return size > 0 ? size : null;
+    }
+
     public static String RemoveInvalidPathChars(String path)
     {
         return String.Concat(path.Split(Path.GetInvalidPathChars()));

--- a/server/RdtClient.Service/Services/DownloadClient.cs
+++ b/server/RdtClient.Service/Services/DownloadClient.cs
@@ -72,10 +72,19 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
                 _ => throw new($"Unknown download client {Type}")
             };
 
+            var expectedFileSize = Type == Data.Enums.DownloadClient.Bezzad
+                ? DownloadHelper.GetExpectedFileSize(torrent, download)
+                : null;
+
             Downloader.DownloadComplete += (_, args) =>
             {
                 Finished = true;
                 Error ??= args.Error;
+
+                if (Error == null && expectedFileSize is > 0)
+                {
+                    Error = ValidateDownloadedFileSize(filePath, expectedFileSize.Value);
+                }
             };
 
             Downloader.DownloadProgress += (_, args) =>
@@ -107,6 +116,38 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
 
             throw new($"An unexpected error occurred preparing download {download.Link} for torrent {torrent.RdName}: {ex.Message}");
         }
+    }
+
+    private static String? ValidateDownloadedFileSize(String? filePath, Int64 expectedFileSize)
+    {
+        if (String.IsNullOrWhiteSpace(filePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var fileInfo = new FileInfo(filePath);
+
+            if (!fileInfo.Exists)
+            {
+                return $"Downloaded file was not found at {filePath} after the download reported success.";
+            }
+
+            var tolerance = Math.Max(64 * 1024, (Int64)(expectedFileSize * 0.01));
+
+            if (Math.Abs(fileInfo.Length - expectedFileSize) > tolerance)
+            {
+                return $"Downloaded file size ({fileInfo.Length:N0} bytes) is outside the expected range " +
+                       $"({expectedFileSize:N0} bytes ±{tolerance:N0}).";
+            }
+        }
+        catch (Exception ex)
+        {
+            return $"Failed to verify the size of the downloaded file at {filePath}: {ex.Message}";
+        }
+
+        return null;
     }
 
     public async Task Cancel()


### PR DESCRIPTION
This PR adds file size checks post download with a 1% tolerance (at minimum 64kb) for variance between expected based on API result and actual file size, just in case there is an issur with the provider. Although this was implemented for #997, it is not a fix for it, as I still can't reproduce it, but this will at least cause the downloads to error whenever it occurs.