### PR TITLE
fix: refresh stale provider download links on retry

### DIFF
--- a/server/RdtClient.Data/Data/DownloadData.cs
+++ b/server/RdtClient.Data/Data/DownloadData.cs
@@ -130,6 +130,21 @@ public class DownloadData(DataContext dataContext, ILogger<DownloadData>? logger
         await dataContext.SaveChangesAsync();
     }
 
+    public async Task UpdatePath(Guid downloadId, String path)
+    {
+        var dbDownload = await dataContext.Downloads
+                                          .FirstOrDefaultAsync(m => m.DownloadId == downloadId);
+
+        if (dbDownload == null)
+        {
+            return;
+        }
+
+        dbDownload.Path = path;
+
+        await dataContext.SaveChangesAsync();
+    }
+
     public async Task UpdateDownloadStarted(Guid downloadId, DateTimeOffset? dateTime)
     {
         var dbDownload = await dataContext.Downloads

--- a/server/RdtClient.Service.Test/Helpers/DownloadLinkMatcherTest.cs
+++ b/server/RdtClient.Service.Test/Helpers/DownloadLinkMatcherTest.cs
@@ -1,0 +1,85 @@
+using RdtClient.Data.Models.Data;
+using RdtClient.Service.Helpers;
+
+namespace RdtClient.Service.Test.Helpers;
+
+public class DownloadLinkMatcherTest
+{
+  [Fact]
+  public void Match_ByFileName_ReturnsMatchingInfo()
+  {
+    var download = new Download
+    {
+      FileName = "episode.mkv",
+      Path = "https://cdn.example.com/old-token/episode.mkv"
+    };
+
+    var infos = new List<DownloadInfo>
+    {
+      new() { FileName = "other.mkv", RestrictedLink = "https://cdn.example.com/new/other.mkv" },
+      new() { FileName = "episode.mkv", RestrictedLink = "https://cdn.example.com/new/episode.mkv" }
+    };
+
+    var result = DownloadLinkMatcher.Match(infos, download);
+
+    Assert.NotNull(result);
+    Assert.Equal("https://cdn.example.com/new/episode.mkv", result.RestrictedLink);
+  }
+
+  [Fact]
+  public void Match_ByUrlSegment_WhenFileNameMissing_ReturnsMatchingInfo()
+  {
+    var download = new Download
+    {
+      Path = "https://cdn.example.com/old-token/Yakuza.Fianc%C3%A9.S01E05.mkv"
+    };
+
+    var infos = new List<DownloadInfo>
+    {
+      new() { FileName = "Yakuza.Fiancé.S01E05.mkv", RestrictedLink = "https://cdn.example.com/new-token/Yakuza.Fianc%C3%A9.S01E05.mkv" }
+    };
+
+    var result = DownloadLinkMatcher.Match(infos, download);
+
+    Assert.NotNull(result);
+    Assert.Equal("https://cdn.example.com/new-token/Yakuza.Fianc%C3%A9.S01E05.mkv", result.RestrictedLink);
+  }
+
+  [Fact]
+  public void Match_SingleFileTorrent_ReturnsOnlyInfo()
+  {
+    var download = new Download
+    {
+      Path = "https://cdn.example.com/old-token/movie.mkv"
+    };
+
+    var infos = new List<DownloadInfo>
+    {
+      new() { FileName = "movie.mkv", RestrictedLink = "https://cdn.example.com/new-token/movie.mkv" }
+    };
+
+    var result = DownloadLinkMatcher.Match(infos, download);
+
+    Assert.NotNull(result);
+    Assert.Equal("https://cdn.example.com/new-token/movie.mkv", result.RestrictedLink);
+  }
+
+  [Fact]
+  public void Match_MultipleFilesWithoutMatch_ReturnsNull()
+  {
+    var download = new Download
+    {
+      Path = "https://cdn.example.com/old-token/unknown.mkv"
+    };
+
+    var infos = new List<DownloadInfo>
+    {
+      new() { FileName = "a.mkv", RestrictedLink = "https://cdn.example.com/new/a.mkv" },
+      new() { FileName = "b.mkv", RestrictedLink = "https://cdn.example.com/new/b.mkv" }
+    };
+
+    var result = DownloadLinkMatcher.Match(infos, download);
+
+    Assert.Null(result);
+  }
+}

--- a/server/RdtClient.Service/Helpers/DownloadLinkMatcher.cs
+++ b/server/RdtClient.Service/Helpers/DownloadLinkMatcher.cs
@@ -1,0 +1,69 @@
+using System.Web;
+using RdtClient.Data.Models.Data;
+
+namespace RdtClient.Service.Helpers;
+
+public static class DownloadLinkMatcher
+{
+    public static DownloadInfo? Match(IList<DownloadInfo> infos, Download download)
+    {
+        if (infos.Count == 0)
+        {
+            return null;
+        }
+
+        if (!String.IsNullOrWhiteSpace(download.FileName))
+        {
+            var byFileName = infos.FirstOrDefault(i => !String.IsNullOrWhiteSpace(i.FileName) &&
+                                                         String.Equals(i.FileName, download.FileName, StringComparison.OrdinalIgnoreCase));
+
+            if (byFileName != null)
+            {
+                return byFileName;
+            }
+        }
+
+        var pathFileName = GetFileNameFromPath(download.Path);
+
+        if (!String.IsNullOrWhiteSpace(pathFileName))
+        {
+            var byPathFileName = infos.FirstOrDefault(i => (!String.IsNullOrWhiteSpace(i.FileName) &&
+                                                            String.Equals(i.FileName, pathFileName, StringComparison.OrdinalIgnoreCase)) ||
+                                                           LinkEndsWithFileName(i.RestrictedLink, pathFileName));
+
+            if (byPathFileName != null)
+            {
+                return byPathFileName;
+            }
+        }
+
+        if (infos.Count == 1)
+        {
+            return infos[0];
+        }
+
+        return null;
+    }
+
+    private static Boolean LinkEndsWithFileName(String link, String fileName)
+    {
+        var linkFileName = GetFileNameFromPath(link);
+
+        return linkFileName != null && String.Equals(linkFileName, fileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static String? GetFileNameFromPath(String path)
+    {
+        if (String.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        if (Uri.TryCreate(path, UriKind.Absolute, out var uri))
+        {
+            return HttpUtility.UrlDecode(uri.Segments.Last());
+        }
+
+        return Path.GetFileName(path);
+    }
+}

--- a/server/RdtClient.Service/Services/Downloads.cs
+++ b/server/RdtClient.Service/Services/Downloads.cs
@@ -31,6 +31,11 @@ public class Downloads(DownloadData downloadData) : IDownloads
         await downloadData.UpdateUnrestrictedLink(downloadId, unrestrictedLink);
     }
 
+    public async Task UpdatePath(Guid downloadId, String path)
+    {
+        await downloadData.UpdatePath(downloadId, path);
+    }
+
     public async Task UpdateFileName(Guid downloadId, String fileName)
     {
         await downloadData.UpdateFileName(downloadId, fileName);

--- a/server/RdtClient.Service/Services/IDownloads.cs
+++ b/server/RdtClient.Service/Services/IDownloads.cs
@@ -10,6 +10,7 @@ public interface IDownloads
     Task<Download?> Get(Guid torrentId, String path);
     Task<DownloadAddResult> TryAddForTorrent(Guid torrentId, DownloadInfo downloadInfo);
     Task UpdateUnrestrictedLink(Guid downloadId, String unrestrictedLink);
+    Task UpdatePath(Guid downloadId, String path);
     Task UpdateFileName(Guid downloadId, String fileName);
     Task UpdateDownloadStarted(Guid downloadId, DateTimeOffset? dateTime);
     Task UpdateDownloadFinished(Guid downloadId, DateTimeOffset? dateTime);

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -610,11 +610,57 @@ public class Torrents(
 
         Log("Unrestricting link", download, download.Torrent);
 
+        if (download.RetryCount > 0)
+        {
+            var refreshedPath = await TryRefreshDownloadPath(download);
+
+            if (refreshedPath != null)
+            {
+                await downloads.UpdatePath(downloadId, refreshedPath);
+                download.Path = refreshedPath;
+            }
+        }
+
         var unrestrictedLink = await DebridClient.Unrestrict(download.Torrent!, download.Path);
 
         await downloads.UpdateUnrestrictedLink(downloadId, unrestrictedLink);
 
         return unrestrictedLink;
+    }
+
+    private async Task<String?> TryRefreshDownloadPath(Download download)
+    {
+        if (download.Torrent == null)
+        {
+            return null;
+        }
+
+        var downloadInfos = await DebridClient.GetDownloadInfos(download.Torrent);
+
+        if (downloadInfos == null || downloadInfos.Count == 0)
+        {
+            Log("No download infos returned while refreshing path", download, download.Torrent);
+
+            return null;
+        }
+
+        var matched = DownloadLinkMatcher.Match(downloadInfos, download);
+
+        if (matched == null)
+        {
+            Log("Could not match download to refreshed provider link", download, download.Torrent);
+
+            return null;
+        }
+
+        if (String.Equals(matched.RestrictedLink, download.Path, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Log("Refreshed download path from provider", download, download.Torrent);
+
+        return matched.RestrictedLink;
     }
 
     public async Task<String> RetrieveFileName(Guid downloadId)


### PR DESCRIPTION
## Summary

Fixes a download retry loop where Aria2 repeatedly fails with HTTP 403 because rdt-client keeps reusing an **expired provider CDN signed URL** stored in `Download.Path`.

When a download fails, `Reset()` clears `Link` but leaves `Path` unchanged. On the next attempt, `UnrestrictLink` runs again against the same stale `Path`. For providers like Premiumize where `Unrestrict()` is a no-op, nothing ever refreshes the URL — so the download retries forever (~1/sec) with the same dead link.

This PR re-fetches download links from the provider via `GetDownloadInfos()` when `RetryCount > 0`, matches the correct file, updates `Path`, and then proceeds with the normal unrestrict flow.

## How I found this

I initially suspected a **long filename** was causing torrents to hang. Example file:

`Yakuza.Fiancé.Raise.wa.Tanin.ga.Ii.S01E05.Young.Lady.Tsubaki.1080p.B-Global.WEB-DL.JPN.AAC2.0.H.265.MSubs-ToonsHub.mkv`

That turned out not to be the issue — the full download path was ~247 characters and the target folder created fine on `G:\tmp\sonarr\`.

The real symptom was different: the download would briefly appear in Aria2, then vanish, and the **retry count climbed at ~1 per second** (600+ and still going). Logs showed:

```
Download reported an error: 22: The response status is not successful. status=403
```

Aria2 error 22 is an HTTP failure; **403 Forbidden** means the CDN rejected the request.

### Ruling out other causes

I first wondered if this was an **Aria2 User-Agent** issue (CDN allowing browsers but blocking `aria2/1.x`). That theory fell apart when I tested the **exact URL rdt-client was using** in a browser — it also returned 403.

The breakthrough was comparing two URLs for the **same file** (I'm on **Premiumize**, not Real Debrid — the app name is legacy but the CDN behaviour is the same):

**rdt-client stored link (403 in browser and Aria2):**

https://3-cdn2-ovh-fra.energycdn.com/cdn3sto/sillyweasel-sto/6a43df2070da50.18300376/426800987/1782832942/321060974b14f09ec7ab5e75e8f0e4257b69d432/9667fb75a88e25ecc0ebe80729ae96462df3b47830bd8d0c6afbb8164d6b0c94/Yakuza.Fianc%C3%A9.Raise.wa.Tanin.ga.Ii.S01E05.Young.Lady.Tsubaki.1080p.B-Global.WEB-DL.JPN.AAC2.0.H.265.MSubs-ToonsHub.mkv

**Fresh link from Premiumize website (downloads fine):**

https://3-cdn2-ovh-fra.energycdn.com/cdn3sto/sillyweasel-sto/6a43df2070da50.18300376/426800987/1782932034/321060974b14f09ec7ab5e75e8f0e4257b69d432/4664658a67d9a451ed3c30405705af60790d28fbbf83233b0bfc7819d439680c/Yakuza.Fianc%C3%A9.Raise.wa.Tanin.ga.Ii.S01E05.Young.Lady.Tsubaki.1080p.B-Global.WEB-DL.JPN.AAC2.0.H.265.MSubs-ToonsHub.mkv

Same host, same file path — but **different timestamp** (`1782832942` vs `1782932034`, ~27 hours apart) and **different signature hash**. The rdt-client URL was an older, expired signed CDN link.

**Retry Torrent** worked as a workaround because it deletes and re-adds the torrent, which triggers a fresh `GetDownloadInfos()` and stores new links.

## Root cause

Provider CDN URLs are **time-limited signed links**. When downloads are first created, rdt-client stores the provider link in `Download.Path` (via `DownloadInfo.RestrictedLink` from `GetDownloadInfos()`).

On per-download retry, `TorrentRunner` calls `Reset()` which clears `Link` but **does not update `Path`**. The next `UnrestrictLink` call therefore uses the same expired URL.

For Premiumize this is especially visible because `Unrestrict()` is a no-op — it returns the link unchanged:

```csharp
public Task<String> Unrestrict(Torrent torrent, String link)
{
    return Task.FromResult(link);
}
```

So the retry loop never gets a fresh signature. Real Debrid and other providers can hit the same class of problem whenever `Path` already holds a CDN URL that has expired and `Unrestrict` does not mint a new one.

## Why fix all providers, not just Premiumize

All debrid clients follow the same download lifecycle in rdt-client:

1. `GetDownloadInfos()` → store `RestrictedLink` in `Download.Path`
2. `UnrestrictLink()` → call `IDebridClient.Unrestrict(Path)` → store result in `Download.Link`
3. Downloader fetches `Link`
4. On failure → `Reset()` (clears `Link`, keeps `Path`) → retry

The stale-`Path` problem is in this shared flow, not in a single provider implementation. Refreshing from `GetDownloadInfos()` on retry is provider-agnostic and safe: if the provider returns the same link, we skip the update; if it returns a fresh one, we use it.

## What this PR changes

1. **`DownloadLinkMatcher`** — matches a `Download` to a `DownloadInfo` from a fresh `GetDownloadInfos()` call by:
   - filename (`Download.FileName`)
   - URL-encoded filename segment from the existing `Path`
   - single-file torrent fallback

2. **`UpdatePath`** — new method on the downloads data/service layer to persist an updated restricted link.

3. **`Torrents.UnrestrictLink`** — when `RetryCount > 0`, calls `TryRefreshDownloadPath()` before unrestricting:
   - fetches current links from the provider
   - matches the download
   - updates `Path` if a newer link is available
   - then runs the existing `Unrestrict` + `UpdateUnrestrictedLink` flow

4. **Unit tests** for `DownloadLinkMatcher` (filename match, URL segment match with encoded Unicode, single-file fallback, multi-file no-match).

## Test plan

- [x] `dotnet test server/RdtClient.Service.Test/RdtClient.Service.Test.csproj` — 219 tests passed
- [x] Reproduce stale-link 403 on Premiumize; confirm automatic retry fetches a fresh link and download completes without **Retry Torrent**
- [x] Single-file torrent: confirm fallback matching still works
- [x] Smoke test with Real Debrid (or other provider) to confirm no regression on first attempt (`RetryCount == 0` should not call refresh)
