### PR TITLE
Allow Bypassing Chown for usage in dockge with Hostpath in TrueNAS

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-rdt-client/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-rdt-client/run
@@ -8,6 +8,10 @@
 	rm -rf /data/rtdclient.pid
 
 # permissions
-echo "Setting permissions"
-chown -R abc:abc \
-	/app /data
+if [ -z "${SKIP_CHOWN}" ] || [ "${SKIP_CHOWN}" = "false" ]; then
+	echo "Setting permissions"
+	chown -R abc:abc \
+		/app /data
+else
+	echo "Skipping permissions (SKIP_CHOWN is set)"
+fi

--- a/root/etc/s6-overlay/s6-rc.d/svc-rdt-client/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-rdt-client/run
@@ -6,9 +6,13 @@ if [ -n "${UMASK_SET}" ] && [ -z "${UMASK}" ]; then
 fi
 
 # permissions
-echo "Setting permissions"
-chown -R abc:abc \
-	/app /data 
+if [ -z "${SKIP_CHOWN}" ] || [ "${SKIP_CHOWN}" = "false" ]; then
+	echo "Setting permissions"
+	chown -R abc:abc \
+		/app /data
+else
+	echo "Skipping permissions (SKIP_CHOWN is set)"
+fi
 
 echo "Changing to /app folder"
 cd /app || exit


### PR DESCRIPTION
When running rdt-client in Docker with host-path volume mounts (common on TrueNAS / Dockge setups), the container runs chown -R abc:abc /app /data on every startup and service restart via the s6-overlay init and service scripts.

This causes two significant issues:

1. Hang-ups on large directory trees — A recursive chown over a mounted downloads folder with thousands of files can take minutes to complete before the service starts.

2. Corrupted permissions on shared mounts — The /data/downloads volume is often shared with other services (e.g. Sonarr, Radarr). Forcing ownership to breaks those services' access to files they manage.

This is a well-known pain point for users running *arr stack containers on NAS systems where host-path mounts are the norm and permissions are managed by the host OS, not the container.

Solution
Added a SKIP_CHOWN environment variable check around the chown calls in both s6 scripts.

```environment:
  - PUID=1000
  - PGID=1000
  - TZ=Europe/London
  - SKIP_CHOWN=true
 ```

When SKIP_CHOWN=true is set, the permission change is skipped entirely. The default behaviour (no env var set, or SKIP_CHOWN=false) is unchanged — fully backwards compatible.