### PR TITLE
fix: SABnzbd API — use RdSize fallback for Size/SizeLeft and add mb/mbleft/bytes/downloaded

### DIFF
--- a/server/RdtClient.Data/Models/Sabnzbd/SabnzbdHistorySlot.cs
+++ b/server/RdtClient.Data/Models/Sabnzbd/SabnzbdHistorySlot.cs
@@ -13,6 +13,12 @@ public class SabnzbdHistorySlot
     [JsonPropertyName("size")]
     public String Size { get; set; } = "0 B";
 
+    [JsonPropertyName("bytes")]
+    public Int64 Bytes { get; set; }
+
+    [JsonPropertyName("downloaded")]
+    public Int64 Downloaded { get; set; }
+
     [JsonPropertyName("status")]
     public String Status { get; set; } = "Completed";
 

--- a/server/RdtClient.Data/Models/Sabnzbd/SabnzbdQueue.cs
+++ b/server/RdtClient.Data/Models/Sabnzbd/SabnzbdQueue.cs
@@ -19,6 +19,12 @@ public class SabnzbdQueue
     [JsonPropertyName("sizeleft")]
     public String SizeLeft { get; set; } = "0 B";
 
+    [JsonPropertyName("mb")]
+    public String Mb { get; set; } = "0.00";
+
+    [JsonPropertyName("mbleft")]
+    public String MbLeft { get; set; } = "0.00";
+
     [JsonPropertyName("noofslots")]
     public Int32 NoOfSlots { get; set; }
 

--- a/server/RdtClient.Data/Models/Sabnzbd/SabnzbdQueueSlot.cs
+++ b/server/RdtClient.Data/Models/Sabnzbd/SabnzbdQueueSlot.cs
@@ -19,6 +19,12 @@ public class SabnzbdQueueSlot
     [JsonPropertyName("sizeleft")]
     public String SizeLeft { get; set; } = "0 B";
 
+    [JsonPropertyName("mb")]
+    public String Mb { get; set; } = "0.00";
+
+    [JsonPropertyName("mbleft")]
+    public String MbLeft { get; set; } = "0.00";
+
     [JsonPropertyName("percentage")]
     public String Percentage { get; set; } = "0";
 

--- a/server/RdtClient.Service/Services/Sabnzbd.cs
+++ b/server/RdtClient.Service/Services/Sabnzbd.cs
@@ -24,11 +24,12 @@ public class Sabnzbd(ILogger<Sabnzbd> logger, Torrents torrents, AppSettings app
 
                                       var dlStats = t.Downloads.Select(m => torrents.GetDownloadStats(m.DownloadId)).ToList();
 
+                                      var dlBytesTotal = dlStats.Sum(m => m.BytesTotal);
+                                      var dlBytesDone = dlStats.Sum(m => m.BytesDone);
+
                                       if (dlStats.Count > 0)
                                       {
-                                          var bytesDone = dlStats.Sum(m => m.BytesDone);
-                                          var bytesTotal = dlStats.Sum(m => m.BytesTotal);
-                                          var downloadProgress = bytesTotal > 0 ? Math.Clamp((Double)bytesDone / bytesTotal, 0.0, 1.0) : 0;
+                                          var downloadProgress = dlBytesTotal > 0 ? Math.Clamp((Double)dlBytesDone / dlBytesTotal, 0.0, 1.0) : 0;
                                           progress = (rdProgress + downloadProgress) / 2.0;
                                       }
                                       else
@@ -51,13 +52,26 @@ public class Sabnzbd(ILogger<Sabnzbd> logger, Torrents torrents, AppSettings app
                                           }
                                       }
 
+                                      var mbBytes = dlBytesTotal > 0 ? dlBytesTotal : (t.RdSize ?? 0);
+                                      var mbLeftBytes = dlBytesTotal > 0
+                                                            ? dlBytesTotal - dlBytesDone
+                                                            : (t.RdSize.HasValue
+                                                                   ? (Int64)(t.RdSize.Value * (1.0 - rdProgress))
+                                                                   : 0);
+
                                       return new SabnzbdQueueSlot
                                       {
                                           Index = index,
                                           NzoId = t.Hash,
                                           Filename = t.RdName ?? t.Hash,
-                                          Size = FileSizeHelper.FormatSize(dlStats.Sum(d => d.BytesTotal)),
-                                          SizeLeft = FileSizeHelper.FormatSize(dlStats.Sum(d => d.BytesTotal - d.BytesDone)),
+                                          Size = dlBytesTotal > 0
+                                                    ? FileSizeHelper.FormatSize(dlBytesTotal)
+                                                    : FileSizeHelper.FormatSize(t.RdSize),
+                                          SizeLeft = dlBytesTotal > 0
+                                                          ? FileSizeHelper.FormatSize(dlBytesTotal - dlBytesDone)
+                                                          : FileSizeHelper.FormatSize(t.RdSize.HasValue ? (Int64)(t.RdSize.Value * (1.0 - rdProgress)) : null),
+                                          Mb = (mbBytes / 1048576.0).ToString("0.00"),
+                                          MbLeft = (Math.Max(mbLeftBytes, 0) / 1048576.0).ToString("0.00"),
                                           Percentage = (progress * 100.0).ToString("0"),
 
                                           Status = t.RdStatus switch
@@ -78,6 +92,9 @@ public class Sabnzbd(ILogger<Sabnzbd> logger, Torrents torrents, AppSettings app
                                   })
                                   .ToList()
         };
+
+        queue.Mb = queue.Slots.Sum(s => Double.Parse(s.Mb)).ToString("0.00");
+        queue.MbLeft = queue.Slots.Sum(s => Double.Parse(s.MbLeft)).ToString("0.00");
 
         return queue;
     }
@@ -107,11 +124,16 @@ public class Sabnzbd(ILogger<Sabnzbd> logger, Torrents torrents, AppSettings app
                                              path = Path.Combine(path, t.RdName);
                                          }
 
+                                         var historyBytesTotal = t.Downloads.Sum(d => d.BytesTotal);
+                                         var totalBytes = historyBytesTotal > 0 ? historyBytesTotal : (t.RdSize ?? 0);
+
                                          return new SabnzbdHistorySlot
                                          {
                                              NzoId = t.Hash,
                                              Name = t.RdName ?? t.Hash,
-                                             Size = FileSizeHelper.FormatSize(t.Downloads.Sum(d => d.BytesTotal)),
+                                             Size = FileSizeHelper.FormatSize(totalBytes),
+                                             Bytes = totalBytes,
+                                             Downloaded = String.IsNullOrWhiteSpace(t.Error) ? totalBytes : 0,
                                              Status = String.IsNullOrWhiteSpace(t.Error) ? "Completed" : "Failed",
                                              Category = t.Category ?? "Default",
                                              Path = path


### PR DESCRIPTION
Fixes #1008

The SABnzbd compatibility API was reporting "size": "0 B" and "sizeleft": "0 B" for all queue items, breaking integration with Sonarr/Radarr/Lidarr.

### Root cause

Size and SizeLeft were computed solely from GetDownloadStats().BytesTotal/BytesDone, which only returns real values while a download is actively being downloaded to the local machine. For queued items or items still being processed by the debrid provider, this returns 0.

### Fix

When download-level byte totals are 0, fall back to Torrent.RdSize (the total file size reported by the debrid provider, persisted in the database). For SizeLeft in the queue, estimate remaining bytes from RdSize * (1 - rdProgress).

### Spec additions

Added fields that the SABnzbd API spec requires but were missing:
- Queue slots: "mb" and "mbleft" (raw megabyte values as strings)
- Queue container: "mb" and "mbleft" (aggregated totals)
- History slots: "bytes" and "downloaded" (raw byte counts)

### Files changed

- server/RdtClient.Data/Models/Sabnzbd/SabnzbdQueueSlot.cs - Added "mb", "mbleft" properties
- server/RdtClient.Data/Models/Sabnzbd/SabnzbdQueue.cs - Added "mb", "mbleft" container aggregation
- server/RdtClient.Data/Models/Sabnzbd/SabnzbdHistorySlot.cs - Added "bytes", "downloaded" properties
- server/RdtClient.Service/Services/Sabnzbd.cs - Size/SizeLeft fall back to RdSize; populate new fields
