### PR TITLE
fix: prevent AutoDelete from removing Finished torrents

### DIFF
--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -740,7 +740,7 @@ public class Torrents(
             {
                 var rdTorrent = torrent.RdId != null && providerTorrentsById.TryGetValue(torrent.RdId, out var providerTorrent) ? providerTorrent : null;
 
-                if (rdTorrent == null && settings.Current.Provider.AutoDelete && torrent.RdStatus != TorrentStatus.Queued)
+                if (rdTorrent == null && settings.Current.Provider.AutoDelete && torrent.RdStatus != TorrentStatus.Queued && torrent.RdStatus != TorrentStatus.Finished)
                 {
                     await Delete(torrent.TorrentId, true, false, true);
                 }


### PR DESCRIPTION
Fixes #1011

When a cached torrent completes on the provider, \GetIdInfoAsync\ (per-torrent endpoint) reports it as \Finished\, but \GetCurrentAsync\ (bulk listing) may have a cache/propagation delay. AutoDelete used the bulk listing exclusively to decide whether a torrent still exists, creating a race where a freshly-finished torrent could be deleted before the downstream *arr app could import it.

Skip AutoDelete for \Finished\ torrents. They were confirmed to exist recently by the authoritative per-torrent endpoint. They will be cleaned up naturally when the downstream app completes its import cycle and calls \TorrentsDelete\, or via the normal \FinishedAction\ cleanup path.

**Change:** 1 file changed, 1 insertion(+), 1 deletion(-) in \server/RdtClient.Service/Services/Torrents.cs\

**Tested:** Overnight on a live Docker/TorBox/Symlink system. Radarr main: 72 grabs, 62 imports, 4 failures, 0 orphans after the fix.