### PR TITLE
Fix/premiumize progress status

### DIFF
--- a/server/RdtClient.Data/Data/TorrentData.cs
+++ b/server/RdtClient.Data/Data/TorrentData.cs
@@ -134,6 +134,7 @@ public class TorrentData(DataContext dataContext, ILogger<TorrentData>? logger =
         dbTorrent.RdSpeed = torrent.RdSpeed;
         dbTorrent.RdSeeders = torrent.RdSeeders;
         dbTorrent.RdFiles = torrent.RdFiles;
+        dbTorrent.ClientKind = torrent.ClientKind;
 
         await dataContext.SaveChangesAsync();
     }

--- a/server/RdtClient.Data/Models/DebridClient/DebridClientTorrent.cs
+++ b/server/RdtClient.Data/Models/DebridClient/DebridClientTorrent.cs
@@ -13,6 +13,7 @@ public class DebridClientTorrent
     public String? Host { get; set; }
     public Int64 Split { get; set; }
     public Int64 Progress { get; set; }
+    public Double ProgressFraction { get; set; }
     public String? Status { get; set; }
     public String? Message { get; set; }
     public Int64 StatusCode { get; set; }

--- a/server/RdtClient.Service.Test/Regression/TorrentPayloadDataTests.cs
+++ b/server/RdtClient.Service.Test/Regression/TorrentPayloadDataTests.cs
@@ -107,6 +107,46 @@ public class TorrentPayloadDataTests : IAsyncLifetime
         Assert.False(await verifyContext.TorrentPayloads.AnyAsync(m => m.TorrentId == torrentId));
     }
 
+    [Fact]
+    public async Task UpdateRdData_ShouldPersistClientKind()
+    {
+        var torrentId = Guid.NewGuid();
+
+        await using (var context = CreateContext())
+        {
+            await context.Database.EnsureCreatedAsync();
+
+            context.Torrents.Add(new()
+            {
+                TorrentId = torrentId,
+                Hash = "hash-client-kind",
+                Added = DateTimeOffset.UtcNow,
+                Type = DownloadType.Torrent
+            });
+
+            await context.SaveChangesAsync();
+        }
+
+        await using (var updateContext = CreateContext())
+        {
+            var torrentData = new TorrentData(updateContext);
+
+            await torrentData.UpdateRdData(new()
+            {
+                TorrentId = torrentId,
+                ClientKind = Provider.Premiumize,
+                RdProgress = 42,
+                RdStatus = TorrentStatus.Downloading
+            });
+        }
+
+        await using var verifyContext = CreateContext();
+        var torrent = await verifyContext.Torrents.SingleAsync(m => m.TorrentId == torrentId);
+
+        Assert.Equal(Provider.Premiumize, torrent.ClientKind);
+        Assert.Equal(42, torrent.RdProgress);
+    }
+
     public Task InitializeAsync()
     {
         return Task.CompletedTask;

--- a/server/RdtClient.Service.Test/Services/PremiumizeProgressTrackerTest.cs
+++ b/server/RdtClient.Service.Test/Services/PremiumizeProgressTrackerTest.cs
@@ -1,0 +1,75 @@
+using RdtClient.Service.Services;
+
+namespace RdtClient.Service.Test.Services;
+
+public class PremiumizeProgressTrackerTest
+{
+    [Fact]
+    public void Update_WhenProgressIncreases_IsNotStalledAndHasSpeed()
+    {
+        var tracker = new PremiumizeProgressTracker();
+        var torrentId = Guid.NewGuid();
+
+        tracker.Update(torrentId, 0.1);
+        Thread.Sleep(50);
+        tracker.Update(torrentId, 0.2);
+
+        Assert.False(tracker.IsStalled(torrentId));
+        Assert.True(tracker.GetSpeedBytesPerSec(torrentId) > 0);
+        Assert.True(tracker.GetProgressPerMin(torrentId) > 0);
+    }
+
+    [Fact]
+    public void Update_WhenNoProgressForStallThreshold_IsStalled()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var tracker = new PremiumizeProgressTracker
+        {
+            UtcNowOverride = () => now
+        };
+        var torrentId = Guid.NewGuid();
+
+        tracker.Update(torrentId, 0.5);
+        now = now.Add(PremiumizeProgressTracker.StallThreshold);
+        tracker.Update(torrentId, 0.5);
+
+        Assert.True(tracker.IsStalled(torrentId));
+    }
+
+    [Fact]
+    public void Update_WhenProgressIncreasesAfterStallPeriod_ResetsStallTimer()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var tracker = new PremiumizeProgressTracker
+        {
+            UtcNowOverride = () => now
+        };
+        var torrentId = Guid.NewGuid();
+
+        tracker.Update(torrentId, 0.5);
+        now = now.Add(PremiumizeProgressTracker.StallThreshold);
+        tracker.Update(torrentId, 0.5);
+
+        Assert.True(tracker.IsStalled(torrentId));
+
+        now = now.Add(TimeSpan.FromSeconds(1));
+        tracker.Update(torrentId, 0.6);
+
+        Assert.False(tracker.IsStalled(torrentId));
+        Assert.True(tracker.GetSpeedBytesPerSec(torrentId) > 0);
+    }
+
+    [Fact]
+    public void Remove_ClearsTrackedState()
+    {
+        var tracker = new PremiumizeProgressTracker();
+        var torrentId = Guid.NewGuid();
+
+        tracker.Update(torrentId, 0.5);
+        tracker.Remove(torrentId);
+
+        Assert.False(tracker.IsStalled(torrentId));
+        Assert.Null(tracker.GetSpeedBytesPerSec(torrentId));
+        Assert.Null(tracker.GetProgressPerMin(torrentId));
+    }
+}

--- a/server/RdtClient.Service.Test/Services/QBittorrentTest.cs
+++ b/server/RdtClient.Service.Test/Services/QBittorrentTest.cs
@@ -12,6 +12,7 @@ public class QBittorrentTest
 {
     private readonly Mock<Authentication> _authenticationMock;
     private readonly Mock<ILogger<QBittorrent>> _loggerMock;
+    private readonly PremiumizeProgressTracker _premiumizeProgressTracker;
     private readonly QBittorrent _qBittorrent;
     private readonly TestSettings _settings;
     private readonly TorrentRunnerState _runnerState;
@@ -22,10 +23,11 @@ public class QBittorrentTest
         _loggerMock = new();
         _settings = new();
         _runnerState = new();
+        _premiumizeProgressTracker = new();
         _torrentsMock = new(null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, _settings, _runnerState);
         _authenticationMock = new(null!, null!, null!);
 
-        _qBittorrent = new(_loggerMock.Object, _settings, _authenticationMock.Object, _torrentsMock.Object, null!, _runnerState);
+        _qBittorrent = new(_loggerMock.Object, _settings, _authenticationMock.Object, _torrentsMock.Object, null!, _runnerState, _premiumizeProgressTracker);
     }
 
     [Fact]
@@ -405,5 +407,75 @@ public class QBittorrentTest
                 Directory.Delete(mappedPath, true);
             }
         }
+    }
+
+    [Fact]
+    public async Task TorrentInfo_PremiumizeWithMovingProgress_ReportsDownloadingWithSyntheticSize()
+    {
+        // Arrange
+        var torrentId = Guid.NewGuid();
+
+        _premiumizeProgressTracker.Update(torrentId, 0.5);
+        _premiumizeProgressTracker.Update(torrentId, 0.6);
+
+        var torrent = new Torrent
+        {
+            TorrentId = torrentId,
+            Hash = "hash1",
+            RdName = "Premiumize Torrent",
+            ClientKind = Provider.Premiumize,
+            RdProgress = 60,
+            RdStatus = TorrentStatus.Downloading,
+            RdSeeders = null,
+            Type = DownloadType.Torrent,
+            Added = DateTimeOffset.UtcNow
+        };
+
+        _torrentsMock.Setup(m => m.Get()).ReturnsAsync([torrent]);
+
+        // Act
+        var result = await _qBittorrent.TorrentInfo();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("downloading", result[0].State);
+        Assert.Equal(PremiumizeProgressTracker.SyntheticSizeBytes, result[0].Size);
+        Assert.Equal((Int64)(PremiumizeProgressTracker.SyntheticSizeBytes * 0.6), result[0].Downloaded);
+        Assert.True(result[0].Downloaded > 0);
+    }
+
+    [Fact]
+    public async Task TorrentInfo_PremiumizeWhenTrackerStalled_ReportsStalledDownloadState()
+    {
+        // Arrange
+        var torrentId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+
+        _premiumizeProgressTracker.UtcNowOverride = () => now;
+        _premiumizeProgressTracker.Update(torrentId, 0.5);
+        now = now.Add(PremiumizeProgressTracker.StallThreshold);
+        _premiumizeProgressTracker.Update(torrentId, 0.5);
+
+        var torrent = new Torrent
+        {
+            TorrentId = torrentId,
+            Hash = "hash1",
+            RdName = "Premiumize Torrent",
+            ClientKind = Provider.Premiumize,
+            RdProgress = 50,
+            RdStatus = TorrentStatus.Downloading,
+            RdSeeders = null,
+            Type = DownloadType.Torrent,
+            Added = DateTimeOffset.UtcNow
+        };
+
+        _torrentsMock.Setup(m => m.Get()).ReturnsAsync([torrent]);
+
+        // Act
+        var result = await _qBittorrent.TorrentInfo();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("stalledDL", result[0].State);
     }
 }

--- a/server/RdtClient.Service.Test/Services/TorrentClients/PremiumizeDebridClientTest.cs
+++ b/server/RdtClient.Service.Test/Services/TorrentClients/PremiumizeDebridClientTest.cs
@@ -2,9 +2,13 @@ using System.Net;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Moq;
+using RdtClient.Data.Enums;
+using RdtClient.Data.Models.Data;
+using RdtClient.Data.Models.DebridClient;
 using RdtClient.Data.Models.Internal;
 using RdtClient.Service.Services;
 using RdtClient.Service.Services.DebridClients;
+using Torrent = RdtClient.Data.Models.Data.Torrent;
 
 namespace RdtClient.Service.Test.Services.TorrentClients;
 
@@ -13,6 +17,7 @@ public class PremiumizeDebridClientTest
     private readonly Mock<IDownloadableFileFilter> _fileFilterMock;
     private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
     private readonly Mock<ILogger<PremiumizeDebridClient>> _loggerMock;
+    private readonly PremiumizeProgressTracker _premiumizeProgressTracker;
     private readonly TestSettings _settings;
 
     public PremiumizeDebridClientTest()
@@ -20,6 +25,7 @@ public class PremiumizeDebridClientTest
         _loggerMock = new();
         _httpClientFactoryMock = new();
         _fileFilterMock = new();
+        _premiumizeProgressTracker = new();
         _settings = new();
         _settings.Current.Provider.ApiKey = "test-api-key";
     }
@@ -194,11 +200,80 @@ public class PremiumizeDebridClientTest
         Assert.Contains("torrent body", handler.RequestBody);
     }
 
+    [Fact]
+    public async Task UpdateData_WhenRunning_UpdatesTrackerAndSetsDerivedSpeed()
+    {
+        // Arrange
+        var torrentId = Guid.NewGuid();
+        var client = CreateClient(new RecordingHttpMessageHandler(_ => JsonResponse("""[]""")));
+        var torrent = new Torrent
+        {
+            TorrentId = torrentId,
+            RdId = "transfer-1"
+        };
+        var transfer = new DebridClientTorrent
+        {
+            Id = "transfer-1",
+            Filename = "test.mkv",
+            Hash = "hash",
+            Progress = 60,
+            ProgressFraction = 0.6,
+            Status = "running",
+            Speed = 0,
+            Seeders = null
+        };
+
+        // Act
+        var result = await client.UpdateData(torrent, transfer);
+
+        // Assert
+        Assert.Equal(TorrentStatus.Downloading, result.RdStatus);
+        Assert.Null(result.RdSeeders);
+        Assert.False(_premiumizeProgressTracker.IsStalled(torrentId));
+    }
+
+    [Fact]
+    public async Task UpdateData_WhenFinished_RemovesTrackerEntry()
+    {
+        // Arrange
+        var torrentId = Guid.NewGuid();
+        var client = CreateClient(new RecordingHttpMessageHandler(_ => JsonResponse("""[]""")));
+        var torrent = new Torrent
+        {
+            TorrentId = torrentId,
+            RdId = "transfer-1"
+        };
+
+        await client.UpdateData(torrent, new DebridClientTorrent
+        {
+            Id = "transfer-1",
+            Filename = "test.mkv",
+            Hash = "hash",
+            Progress = 60,
+            ProgressFraction = 0.6,
+            Status = "running"
+        });
+
+        // Act
+        await client.UpdateData(torrent, new DebridClientTorrent
+        {
+            Id = "transfer-1",
+            Filename = "test.mkv",
+            Hash = "hash",
+            Progress = 100,
+            ProgressFraction = 1.0,
+            Status = "finished"
+        });
+
+        // Assert
+        Assert.Null(_premiumizeProgressTracker.GetSpeedBytesPerSec(torrentId));
+    }
+
     private PremiumizeDebridClient CreateClient(RecordingHttpMessageHandler handler)
     {
         _httpClientFactoryMock.Setup(m => m.CreateClient(It.IsAny<String>())).Returns(new HttpClient(handler));
 
-        return new(_loggerMock.Object, _httpClientFactoryMock.Object, _fileFilterMock.Object, _settings);
+        return new(_loggerMock.Object, _httpClientFactoryMock.Object, _fileFilterMock.Object, _settings, _premiumizeProgressTracker);
     }
 
     private static HttpResponseMessage JsonResponse(String json, HttpStatusCode statusCode = HttpStatusCode.OK)

--- a/server/RdtClient.Service.Test/Services/TorrentRunnerTest.cs
+++ b/server/RdtClient.Service.Test/Services/TorrentRunnerTest.cs
@@ -63,7 +63,7 @@ public class TorrentRunnerTest
         var torrentRunner = new TorrentRunner(Mock.Of<ILogger<TorrentRunner>>(),
                                               torrents,
                                               new(null!),
-                                              new(null!, torrents),
+                                              new(null!, torrents, new PremiumizeProgressTracker()),
                                               Mock.Of<IHttpClientFactory>(),
                                               new RateLimitCoordinator(),
                                               testSettings,

--- a/server/RdtClient.Service/DiConfig.cs
+++ b/server/RdtClient.Service/DiConfig.cs
@@ -52,6 +52,7 @@ public static class DiConfig
         services.AddSingleton<IDownloadableFileFilter, DownloadableFileFilter>();
         services.AddSingleton<ITrackerListGrabber, TrackerListGrabber>();
         services.AddSingleton<IEnricher, Enricher>();
+        services.AddSingleton<IPremiumizeProgressTracker, PremiumizeProgressTracker>();
 
         services.AddScoped<IAuthorizationHandler, AuthSettingHandler>();
         services.AddScoped<IAuthorizationHandler, SabnzbdHandler>();

--- a/server/RdtClient.Service/Helpers/TorrentDtoMapper.cs
+++ b/server/RdtClient.Service/Helpers/TorrentDtoMapper.cs
@@ -1,31 +1,39 @@
 using RdtClient.Data.Enums;
 using RdtClient.Data.Models.Data;
 using RdtClient.Data.Models.Internal;
+using RdtClient.Service.Services;
 
 namespace RdtClient.Service.Helpers;
 
 public static class TorrentDtoMapper
 {
-    public static TorrentDto ToListDto(Torrent torrent, Func<Guid, (Int64 Speed, Int64 BytesTotal, Int64 BytesDone)> getDownloadStats)
+    public static TorrentDto ToListDto(Torrent torrent,
+                                       Func<Guid, (Int64 Speed, Int64 BytesTotal, Int64 BytesDone)> getDownloadStats,
+                                       IPremiumizeProgressTracker? premiumizeProgressTracker = null)
     {
-        return ToDto(torrent, getDownloadStats, includeDownloads: false, includeFiles: false, includeFileOrMagnet: false);
+        return ToDto(torrent, getDownloadStats, includeDownloads: false, includeFiles: false, includeFileOrMagnet: false, premiumizeProgressTracker);
     }
 
-    public static TorrentDto ToUpdateDto(Torrent torrent, Func<Guid, (Int64 Speed, Int64 BytesTotal, Int64 BytesDone)> getDownloadStats)
+    public static TorrentDto ToUpdateDto(Torrent torrent,
+                                         Func<Guid, (Int64 Speed, Int64 BytesTotal, Int64 BytesDone)> getDownloadStats,
+                                         IPremiumizeProgressTracker? premiumizeProgressTracker = null)
     {
-        return ToDto(torrent, getDownloadStats, includeDownloads: true, includeFiles: false, includeFileOrMagnet: false);
+        return ToDto(torrent, getDownloadStats, includeDownloads: true, includeFiles: false, includeFileOrMagnet: false, premiumizeProgressTracker);
     }
 
-    public static TorrentDto ToDetailDto(Torrent torrent, Func<Guid, (Int64 Speed, Int64 BytesTotal, Int64 BytesDone)> getDownloadStats)
+    public static TorrentDto ToDetailDto(Torrent torrent,
+                                         Func<Guid, (Int64 Speed, Int64 BytesTotal, Int64 BytesDone)> getDownloadStats,
+                                         IPremiumizeProgressTracker? premiumizeProgressTracker = null)
     {
-        return ToDto(torrent, getDownloadStats, includeDownloads: true, includeFiles: true, includeFileOrMagnet: true);
+        return ToDto(torrent, getDownloadStats, includeDownloads: true, includeFiles: true, includeFileOrMagnet: true, premiumizeProgressTracker);
     }
 
     private static TorrentDto ToDto(Torrent torrent,
                                     Func<Guid, (Int64 Speed, Int64 BytesTotal, Int64 BytesDone)> getDownloadStats,
                                     Boolean includeDownloads,
                                     Boolean includeFiles,
-                                    Boolean includeFileOrMagnet)
+                                    Boolean includeFileOrMagnet,
+                                    IPremiumizeProgressTracker? premiumizeProgressTracker)
     {
         var downloads = includeDownloads ? torrent.Downloads.Select(download => ToDto(download, getDownloadStats)).ToList() : [];
 
@@ -68,7 +76,7 @@ public static class TorrentDtoMapper
             RdEnded = torrent.RdEnded,
             RdSpeed = torrent.RdSpeed,
             RdSeeders = torrent.RdSeeders,
-            StatusText = GetStatusText(torrent, getDownloadStats),
+            StatusText = GetStatusText(torrent, getDownloadStats, premiumizeProgressTracker),
             FilesCount = torrent.Files.Count,
             DownloadsCount = torrent.Downloads.Count,
             Files = includeFiles ? torrent.Files : [],
@@ -102,7 +110,9 @@ public static class TorrentDtoMapper
         };
     }
 
-    private static String GetStatusText(Torrent torrent, Func<Guid, (Int64 Speed, Int64 BytesTotal, Int64 BytesDone)> getDownloadStats)
+    private static String GetStatusText(Torrent torrent,
+                                          Func<Guid, (Int64 Speed, Int64 BytesTotal, Int64 BytesDone)> getDownloadStats,
+                                          IPremiumizeProgressTracker? premiumizeProgressTracker)
     {
         if (!String.IsNullOrWhiteSpace(torrent.Error))
         {
@@ -219,6 +229,8 @@ public static class TorrentDtoMapper
         return torrent.RdStatus switch
         {
             TorrentStatus.Queued => "Not Yet Added to Provider",
+            TorrentStatus.Downloading when torrent.ClientKind == Provider.Premiumize && torrent.Type != DownloadType.Nzb && premiumizeProgressTracker != null =>
+                GetPremiumizeDownloadingStatus(torrent, premiumizeProgressTracker),
             TorrentStatus.Downloading when torrent.RdSeeders < 1 && torrent.Type != DownloadType.Nzb => "Torrent stalled",
             TorrentStatus.Downloading => $"{prefix} downloading ({torrent.RdProgress}% - {FileSizeHelper.FormatSize(torrent.RdSpeed)}/s)",
             TorrentStatus.Processing => $"{prefix} processing",
@@ -228,5 +240,22 @@ public static class TorrentDtoMapper
             TorrentStatus.Uploading => $"{prefix} uploading",
             _ => "Unknown status"
         };
+    }
+
+    private static String GetPremiumizeDownloadingStatus(Torrent torrent, IPremiumizeProgressTracker premiumizeProgressTracker)
+    {
+        if (premiumizeProgressTracker.IsStalled(torrent.TorrentId))
+        {
+            return $"Torrent stalled ({torrent.RdProgress}%)";
+        }
+
+        var progressPerMin = premiumizeProgressTracker.GetProgressPerMin(torrent.TorrentId);
+
+        if (progressPerMin.HasValue)
+        {
+            return $"Torrent downloading ({torrent.RdProgress}% - ~{progressPerMin.Value:0.0}%/min)";
+        }
+
+        return $"Torrent downloading ({torrent.RdProgress}%)";
     }
 }

--- a/server/RdtClient.Service/RdtClient.Service.csproj
+++ b/server/RdtClient.Service/RdtClient.Service.csproj
@@ -33,4 +33,8 @@
     <ProjectReference Include="..\RdtClient.Data\RdtClient.Data.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="RdtClient.Service.Test" />
+  </ItemGroup>
+
 </Project>

--- a/server/RdtClient.Service/Services/DebridClients/PremiumizeDebridClient.cs
+++ b/server/RdtClient.Service/Services/DebridClients/PremiumizeDebridClient.cs
@@ -12,8 +12,12 @@ using Torrent = RdtClient.Data.Models.Data.Torrent;
 
 namespace RdtClient.Service.Services.DebridClients;
 
-public class PremiumizeDebridClient(ILogger<PremiumizeDebridClient> logger, IHttpClientFactory httpClientFactory, IDownloadableFileFilter fileFilter, ISettings settings)
-    : IDebridClient
+public class PremiumizeDebridClient(
+    ILogger<PremiumizeDebridClient> logger,
+    IHttpClientFactory httpClientFactory,
+    IDownloadableFileFilter fileFilter,
+    ISettings settings,
+    IPremiumizeProgressTracker premiumizeProgressTracker) : IDebridClient
 {
     private const String TransferCreateUrl = "https://www.premiumize.me/api/transfer/create";
 
@@ -121,8 +125,19 @@ public class PremiumizeDebridClient(ILogger<PremiumizeDebridClient> logger, IHtt
                 "running" => TorrentStatus.Downloading,
                 "seeding" => TorrentStatus.Finished,
                 "finished" => TorrentStatus.Finished,
+                "error" => TorrentStatus.Error,
                 _ => TorrentStatus.Error
             };
+
+            if (torrent.RdStatus == TorrentStatus.Downloading)
+            {
+                premiumizeProgressTracker.Update(torrent.TorrentId, torrentClientTorrent.ProgressFraction);
+                torrent.RdSpeed = premiumizeProgressTracker.GetSpeedBytesPerSec(torrent.TorrentId) ?? 0;
+            }
+            else if (torrent.RdStatus is TorrentStatus.Finished or TorrentStatus.Error)
+            {
+                premiumizeProgressTracker.Remove(torrent.TorrentId);
+            }
         }
         catch (PremiumizeException ex)
         {
@@ -370,6 +385,7 @@ public class PremiumizeDebridClient(ILogger<PremiumizeDebridClient> logger, IHtt
             Host = null,
             Split = 0,
             Progress = (Int64)((transfer.Progress ?? 1.0) * 100.0),
+            ProgressFraction = transfer.Progress ?? 0.0,
             Status = transfer.Status,
             Message = transfer.Message,
             StatusCode = 0,
@@ -381,7 +397,7 @@ public class PremiumizeDebridClient(ILogger<PremiumizeDebridClient> logger, IHtt
             ],
             Ended = null,
             Speed = 0,
-            Seeders = 0
+            Seeders = null
         };
     }
 

--- a/server/RdtClient.Service/Services/IPremiumizeProgressTracker.cs
+++ b/server/RdtClient.Service/Services/IPremiumizeProgressTracker.cs
@@ -1,0 +1,14 @@
+namespace RdtClient.Service.Services;
+
+public interface IPremiumizeProgressTracker
+{
+    void Update(Guid torrentId, Double progressFraction);
+
+    Boolean IsStalled(Guid torrentId);
+
+    Int64? GetSpeedBytesPerSec(Guid torrentId);
+
+    Double? GetProgressPerMin(Guid torrentId);
+
+    void Remove(Guid torrentId);
+}

--- a/server/RdtClient.Service/Services/PremiumizeProgressTracker.cs
+++ b/server/RdtClient.Service/Services/PremiumizeProgressTracker.cs
@@ -1,0 +1,130 @@
+using System.Collections.Concurrent;
+
+namespace RdtClient.Service.Services;
+
+public class PremiumizeProgressTracker : IPremiumizeProgressTracker
+{
+    public const Int64 SyntheticSizeBytes = 1_000_000_000;
+
+    public static readonly TimeSpan StallThreshold = TimeSpan.FromMinutes(20);
+
+    private readonly ConcurrentDictionary<Guid, Entry> _entries = new();
+
+    internal Func<DateTimeOffset>? UtcNowOverride { get; set; }
+
+    private DateTimeOffset UtcNow => UtcNowOverride?.Invoke() ?? DateTimeOffset.UtcNow;
+
+    public void Update(Guid torrentId, Double progressFraction)
+    {
+        var now = UtcNow;
+        var clampedProgress = Math.Clamp(progressFraction, 0.0, 1.0);
+
+        _entries.AddOrUpdate(
+            torrentId,
+            _ => CreateEntry(clampedProgress, now),
+            (_, existing) => UpdateEntry(existing, clampedProgress, now));
+    }
+
+    public Boolean IsStalled(Guid torrentId)
+    {
+        if (!_entries.TryGetValue(torrentId, out var entry))
+        {
+            return false;
+        }
+
+        return entry.IsStalled;
+    }
+
+    public Int64? GetSpeedBytesPerSec(Guid torrentId)
+    {
+        if (!_entries.TryGetValue(torrentId, out var entry))
+        {
+            return null;
+        }
+
+        return entry.LastSpeedBytesPerSec;
+    }
+
+    public Double? GetProgressPerMin(Guid torrentId)
+    {
+        if (!_entries.TryGetValue(torrentId, out var entry))
+        {
+            return null;
+        }
+
+        return entry.LastProgressPerMin;
+    }
+
+    public void Remove(Guid torrentId)
+    {
+        _entries.TryRemove(torrentId, out _);
+    }
+
+    private static Entry CreateEntry(Double progress, DateTimeOffset now)
+    {
+        return new()
+        {
+            LastProgress = progress,
+            LastProgressAt = now,
+            LastUpdatedAt = now,
+            IsStalled = false
+        };
+    }
+
+    private static Entry UpdateEntry(Entry existing, Double progress, DateTimeOffset now)
+    {
+        var elapsed = now - existing.LastUpdatedAt;
+        var progressDelta = progress - existing.LastProgress;
+
+        if (progressDelta > 0.0 && elapsed.TotalSeconds > 0)
+        {
+            var speedBytesPerSec = (Int64)((progressDelta * SyntheticSizeBytes) / elapsed.TotalSeconds);
+            var progressPerMin = progressDelta * 100.0 / elapsed.TotalMinutes;
+
+            return existing with
+            {
+                LastProgress = progress,
+                LastProgressAt = now,
+                LastUpdatedAt = now,
+                LastSpeedBytesPerSec = Math.Max(speedBytesPerSec, 0),
+                LastProgressPerMin = progressPerMin,
+                IsStalled = false
+            };
+        }
+
+        if (progress > existing.LastProgress)
+        {
+            return existing with
+            {
+                LastProgress = progress,
+                LastProgressAt = now,
+                LastUpdatedAt = now,
+                IsStalled = false
+            };
+        }
+
+        var stalled = now - existing.LastProgressAt >= StallThreshold;
+
+        return existing with
+        {
+            LastProgress = progress,
+            LastUpdatedAt = now,
+            IsStalled = stalled
+        };
+    }
+
+    private sealed record Entry
+    {
+        public required Double LastProgress { get; init; }
+
+        public required DateTimeOffset LastProgressAt { get; init; }
+
+        public required DateTimeOffset LastUpdatedAt { get; init; }
+
+        public Int64 LastSpeedBytesPerSec { get; init; }
+
+        public Double? LastProgressPerMin { get; init; }
+
+        public Boolean IsStalled { get; init; }
+    }
+}

--- a/server/RdtClient.Service/Services/QBittorrent.cs
+++ b/server/RdtClient.Service/Services/QBittorrent.cs
@@ -5,7 +5,7 @@ using RdtClient.Data.Models.QBittorrent;
 
 namespace RdtClient.Service.Services;
 
-public class QBittorrent(ILogger<QBittorrent> logger, ISettings settings, Authentication authentication, Torrents torrents, Downloads downloads, ITorrentRunnerState runnerState)
+public class QBittorrent(ILogger<QBittorrent> logger, ISettings settings, Authentication authentication, Torrents torrents, Downloads downloads, ITorrentRunnerState runnerState, IPremiumizeProgressTracker premiumizeProgressTracker)
 {
     public async Task<Boolean> AuthLogin(String userName, String password)
     {
@@ -233,6 +233,12 @@ public class QBittorrent(ILogger<QBittorrent> logger, ISettings settings, Authen
             var speed = torrent.RdSpeed ?? 0;
             var bytesDone = (Int64)(bytesTotal * rdProgress);
 
+            if (torrent.ClientKind == Provider.Premiumize && bytesTotal == 0)
+            {
+                bytesTotal = PremiumizeProgressTracker.SyntheticSizeBytes;
+                bytesDone = (Int64)(bytesTotal * rdProgress);
+            }
+
             Double progress;
 
             if (torrent.Completed != null)
@@ -327,7 +333,7 @@ public class QBittorrent(ILogger<QBittorrent> logger, ISettings settings, Authen
             {
                 result.State = "pausedUP";
             }
-            else if (torrent.RdStatus == TorrentStatus.Downloading && torrent.RdSeeders < 1)
+            else if (torrent.RdStatus == TorrentStatus.Downloading && IsProviderStalled(torrent))
             {
                 result.State = "stalledDL";
             }
@@ -885,4 +891,9 @@ public class QBittorrent(ILogger<QBittorrent> logger, ISettings settings, Authen
             }
         ];
     }
+
+    private Boolean IsProviderStalled(Torrent torrent) =>
+        torrent.ClientKind == Provider.Premiumize
+            ? premiumizeProgressTracker.IsStalled(torrent.TorrentId)
+            : torrent.RdSeeders < 1 && torrent.Type != DownloadType.Nzb;
 }

--- a/server/RdtClient.Service/Services/RemoteService.cs
+++ b/server/RdtClient.Service/Services/RemoteService.cs
@@ -4,13 +4,13 @@ using RdtClient.Service.Helpers;
 
 namespace RdtClient.Service.Services;
 
-public class RemoteService(IHubContext<RdtHub> hub, Torrents torrents)
+public class RemoteService(IHubContext<RdtHub> hub, Torrents torrents, IPremiumizeProgressTracker premiumizeProgressTracker)
 {
     public async Task Update()
     {
         var allTorrents = await torrents.Get();
 
-        var torrentDtos = allTorrents.Select(torrent => TorrentDtoMapper.ToUpdateDto(torrent, torrents.GetDownloadStats))
+        var torrentDtos = allTorrents.Select(torrent => TorrentDtoMapper.ToUpdateDto(torrent, torrents.GetDownloadStats, premiumizeProgressTracker))
                                      .ToList();
 
         await hub.Clients.All.SendCoreAsync("update",

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -1242,7 +1242,8 @@ public class Torrents(
                    torrent.RdEnded,
                    torrent.RdSpeed,
                    torrent.RdSeeders,
-                   torrent.RdFiles);
+                   torrent.RdFiles,
+                   torrent.ClientKind);
     }
 
     private readonly record struct TorrentRdState(
@@ -1257,7 +1258,8 @@ public class Torrents(
         DateTimeOffset? RdEnded,
         Int64? RdSpeed,
         Int64? RdSeeders,
-        String? RdFiles);
+        String? RdFiles,
+        Provider? ClientKind);
 
     private void Log(String message, Download? download, Torrent? torrent)
     {

--- a/server/RdtClient.Web.Test/Controllers/QBittorrentControllerTest.cs
+++ b/server/RdtClient.Web.Test/Controllers/QBittorrentControllerTest.cs
@@ -18,7 +18,7 @@ public class QBittorrentControllerTest
     public QBittorrentControllerTest()
     {
         _settings = new();
-        _qBittorrentMock = new(new Mock<ILogger<QBittorrent>>().Object, _settings, null!, null!, null!, new TorrentRunnerState());
+        _qBittorrentMock = new(new Mock<ILogger<QBittorrent>>().Object, _settings, null!, null!, null!, new TorrentRunnerState(), new PremiumizeProgressTracker());
         _torrentsMock = new(null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, _settings, new TorrentRunnerState());
 
         _controller = new(new Mock<ILogger<QBittorrentController>>().Object,

--- a/server/RdtClient.Web.Test/Controllers/TorrentsControllerNzbTest.cs
+++ b/server/RdtClient.Web.Test/Controllers/TorrentsControllerNzbTest.cs
@@ -20,7 +20,7 @@ public class TorrentsControllerNzbTest
         _torrentsMock = new(null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, new TestSettings(), new TorrentRunnerState());
         _loggerMock = new();
         _coordinatorMock = new();
-        _controller = new(_loggerMock.Object, _torrentsMock.Object, null!, _coordinatorMock.Object);
+        _controller = new(_loggerMock.Object, _torrentsMock.Object, null!, _coordinatorMock.Object, new PremiumizeProgressTracker());
     }
 
     [Fact]

--- a/server/RdtClient.Web/Controllers/TorrentsController.cs
+++ b/server/RdtClient.Web/Controllers/TorrentsController.cs
@@ -13,7 +13,7 @@ namespace RdtClient.Web.Controllers;
 
 [Authorize(Policy = "AuthSetting")]
 [Route("Api/Torrents")]
-public class TorrentsController(ILogger<TorrentsController> logger, Torrents torrents, TorrentRunner torrentRunner, IRateLimitCoordinator coordinator) : Controller
+public class TorrentsController(ILogger<TorrentsController> logger, Torrents torrents, TorrentRunner torrentRunner, IRateLimitCoordinator coordinator, IPremiumizeProgressTracker premiumizeProgressTracker) : Controller
 {
     [HttpGet]
     [Route("")]
@@ -21,7 +21,7 @@ public class TorrentsController(ILogger<TorrentsController> logger, Torrents tor
     {
         var results = await torrents.Get();
 
-        var torrentDtos = results.Select(torrent => TorrentDtoMapper.ToListDto(torrent, torrents.GetDownloadStats))
+        var torrentDtos = results.Select(torrent => TorrentDtoMapper.ToListDto(torrent, torrents.GetDownloadStats, premiumizeProgressTracker))
                                  .ToList();
 
         return Ok(torrentDtos);
@@ -43,7 +43,7 @@ public class TorrentsController(ILogger<TorrentsController> logger, Torrents tor
             file.Torrent = null;
         }
 
-        var torrentDto = TorrentDtoMapper.ToDetailDto(torrent, torrents.GetDownloadStats);
+        var torrentDto = TorrentDtoMapper.ToDetailDto(torrent, torrents.GetDownloadStats, premiumizeProgressTracker);
 
         return Ok(torrentDto);
     }


### PR DESCRIPTION
## Summary

Fixes false **stalled** reporting for Premiumize torrents during the provider download phase.

Premiumize's `/api/transfer/list` only returns `status`, `progress` (0.0–1.0), and `message` — no seeders, speed, or byte counts. rdt-client previously mapped `Seeders = 0`, which triggered seeder-based stall logic shared with Real-Debrid and other providers. Every active Premiumize download appeared stalled in the web UI (`Torrent stalled`) and in the fake qBittorrent API (`state: stalledDL`), causing tools like **Cleanuparr** to treat healthy downloads as stuck and remove them after repeated stall strikes.

This PR tracks Premiumize progress over time instead, uses that for stall detection (20-minute threshold), exposes synthetic byte counts for the qBittorrent API, and shows Premiumize-specific status text (`~/min`) in the web UI. A follow-up fix persists `ClientKind` to the database so provider-specific logic actually applies after torrents are reloaded from SQLite.

## How I found this

I use rdt-client's qBittorrent API with **Cleanuparr**. Premiumize torrents in the provider download phase were consistently reported as `stalledDL`, accumulating stall strikes and getting removed even while Premiumize showed them actively downloading.

Investigating the code path:

- `PremiumizeDebridClient.Map()` hardcoded `Seeders = 0`, `Speed = 0`, `Bytes = 0`
- `QBittorrent.cs` and `TorrentDtoMapper.cs` treat `RdSeeders < 1` as stalled for non-NZB torrents
- Cleanuparr only checks qBittorrent `state`, so every Premiumize provider-phase download looked stuck

Premiumize's API docs confirm there is no per-transfer detail endpoint with bytes or peers — only `progress` as a float and `status`. There is also no way to derive real total size from progress alone during an in-flight transfer.

### Ruling out other causes

- **Not a Premiumize outage** — progress % was moving in the Premiumize web UI while rdt-client reported stalled
- **Not Cleanuparr misconfiguration** — it was correctly reacting to `stalledDL` from rdt-client
- **Not a frontend bug** — the backend `statusText` and qBittorrent state both used the same seeder heuristic

### Testing the fix locally

After deploying a local build, provider-phase torrents showed as actively downloading instead of stalled. Initially the UI still displayed synthetic **KB/s** (derived speed formatted like a real transfer rate). That led to a second discovery: `ClientKind` was set in memory during provider polls but **never persisted** in `UpdateRdData`, so torrents reloaded from the database had `ClientKind = null` and fell back to the generic status format. Persisting `ClientKind` fixed the UI to show the intended `Torrent downloading (60% - ~0.4%/min)` format.

## Root cause

Two related problems:

1. **Wrong stall heuristic for Premiumize** — stall detection assumed all providers expose seeder health. Premiumize does not; `Seeders = 0` meant "unknown", not "dead".

2. **`ClientKind` not saved** — `PremiumizeDebridClient.UpdateData` set `torrent.ClientKind = Provider.Premiumize` in memory, but `TorrentData.UpdateRdData` did not write it to the database. Any code path that reloads torrents from SQLite (`torrents.Get()` for websockets, API list, qBittorrent) saw `ClientKind = null`, missing Premiumize-specific branches for status text, synthetic qBittorrent bytes, and tracker-based stall detection.

## Solution

Track Premiumize `progress` over time in an in-memory singleton (`PremiumizeProgressTracker`):

- **Not stalled** when progress increases between polls
- **Stalled** when progress is unchanged for ≥ 20 minutes
- Derive `RdSpeed` (bytes/s) from progress deltas using a 1 GB synthetic base (for qBittorrent/Cleanuparr compatibility only — not real bytes)
- Derive `~/min` for web UI status text (honest estimate from the only data Premiumize provides)

Real-Debrid and other providers are unchanged — they continue to use seeder-based stall logic.

### Why a synthetic 1 GB total for qBittorrent

Premiumize provides no byte counts during `running`. Cleanuparr and other qBittorrent consumers expect `size` and `downloaded` to move with progress. A fixed 1 GB synthetic total lets `downloaded = size × progress%` increment as Premiumize progress advances, without pretending we know the real release size.

### Why `~/min` instead of KB/s in the UI

The derived KB/s is computed from the same synthetic base (`deltaProgress × 1 GB / elapsed`) and looks like a real transfer speed. Showing `~/min` makes it clear we are estimating from Premiumize's done-% over time, not reporting actual bandwidth.

## What this PR changes

### Premiumize progress tracker

- **`IPremiumizeProgressTracker` / `PremiumizeProgressTracker`** — singleton, in-memory per `TorrentId`
  - `SyntheticSizeBytes = 1_000_000_000` (1 GB)
  - `StallThreshold = 20 minutes`
  - `Update`, `IsStalled`, `GetSpeedBytesPerSec`, `GetProgressPerMin`, `Remove`

### Premiumize debrid client

- Inject progress tracker
- `Map()`: `Seeders = null` (unknown, not zero), store raw `ProgressFraction`
- On `running`: update tracker, set `RdSpeed` from derived bytes/s
- On `finished` / `error`: remove tracker entry
- Explicit `"error"` → `TorrentStatus.Error`

### qBittorrent API (Cleanuparr / Sonarr / Radarr)

- Premiumize torrents with no `RdSize`: synthetic 1 GB `size` / `downloaded`
- Replace `RdSeeders < 1` stall check with `IsProviderStalled()` — tracker for Premiumize, seeders for others

### Web UI status text

- `TorrentDtoMapper` accepts `IPremiumizeProgressTracker` (threaded through `TorrentsController`, `RemoteService`)
- Premiumize provider-download phase:
  - Active with rate: `Torrent downloading (60% - ~0.2%/min)`
  - Active, first poll: `Torrent downloading (60%)`
  - Stalled: `Torrent stalled (60%)`
- No frontend changes — API `statusText` is preferred over `torrent-status.pipe.ts`

### ClientKind persistence (second commit)

- **`TorrentData.UpdateRdData`** — persist `ClientKind`
- **`Torrents.CaptureRdState`** — include `ClientKind` so first provider poll triggers a save
- Regression test: `UpdateRdData_ShouldPersistClientKind`

No database migration — `ClientKind` column already exists; existing rows populate on the next provider poll.

## Expected behaviour

| Situation | qBittorrent `state` | Web UI status | Cleanuparr |
|-----------|---------------------|---------------|------------|
| Premiumize `running`, progress moving | `downloading` | `Torrent downloading (60% - ~0.2%/min)` | Left alone |
| Premiumize `running`, no progress 20+ min | `stalledDL` | `Torrent stalled (60%)` | Stall rules apply |
| Real-Debrid / others | Unchanged (seeder-based) | Unchanged | Unchanged |

## Out of scope

- DB migration for progress history (in-memory is sufficient; restart resets stall timers ~20 min)
- Premiumize `message` field in UI
- Parsing torrent files or release sizes for real byte totals
- ETA display (could be a follow-up; `~/min` is the current honest metric)

## Test plan

- [x] `PremiumizeProgressTrackerTest` — speed on progress increase, stall after 20 min, stall reset, remove
- [x] `PremiumizeDebridClientTest` — tracker integration on `UpdateData`
- [x] `QBittorrentTest` — Premiumize moving progress → `downloading` + synthetic size; stalled tracker → `stalledDL`
- [x] `TorrentPayloadDataTests.UpdateRdData_ShouldPersistClientKind`
- [x] `dotnet test server/RdtClient.Service.Test/RdtClient.Service.Test.csproj`
- [x] Manual: Premiumize provider-phase torrents show `~/min` (not fake KB/s) and are not falsely stalled
- [x] Manual: Cleanuparr leaves healthy Premiumize downloads alone
- [x] Manual: confirm genuinely stuck Premiumize transfer reports `stalledDL` after 20+ minutes without progress
