### PR TITLE
Fix mobile list view colors in dark mode

### DIFF
--- a/client/src/app/torrent-table/torrent-table.component.scss
+++ b/client/src/app/torrent-table/torrent-table.component.scss
@@ -25,6 +25,10 @@ table {
 
   &:active {
     background-color: hsl(0, 0%, 96%);
+
+    @media (prefers-color-scheme: dark) {
+      background-color: hsl(0, 0%, 20%);
+    }
   }
 }
 
@@ -53,6 +57,10 @@ table {
   white-space: nowrap;
   margin-bottom: 0.375rem;
   color: hsl(0, 0%, 21%);
+
+  @media (prefers-color-scheme: dark) {
+    color: hsl(0, 0%, 80%);
+  }
 }
 
 .mobile-card-details {
@@ -64,10 +72,18 @@ table {
 .mobile-card-detail {
   font-size: 0.8rem;
   color: hsl(0, 0%, 29%);
+  @media (prefers-color-scheme: dark) {
+    color: hsl(0, 0%, 70%);
+  }
+
   white-space: nowrap;
 
   .detail-label {
     color: hsl(0, 0%, 48%);
+    @media (prefers-color-scheme: dark) {
+      color: hsl(0, 0%, 60%);
+    }
+
     font-size: 0.72rem;
     text-transform: uppercase;
     letter-spacing: 0.03em;


### PR DESCRIPTION
Fixes barely readable text color in mobile view with dark mode active.

The issue is mainly that while the project is using bluma this specific mobile view is using custom styling and colors which don't respect dark mode.

Proper fix would be to switch to bluma-based styling, but this is good enough hotfix for now IMO.

Resolves #1015

| BEFORE |  AFTER  |
| --- | --- |
| <img width="766" height="572" alt="Screenshot 2026-07-16 090845" src="https://github.com/user-attachments/assets/05e4fedd-a80e-4d94-a1a2-3f79c6d92234" /> | <img width="771" height="572" alt="Screenshot 2026-07-16 090818" src="https://github.com/user-attachments/assets/0a1b47f0-b108-4d37-8f80-7cedfb99185c" /> |
