### PR TITLE
Allow uploading multiple torrent files in the Add Torrent form

### DIFF
--- a/client/src/app/add-new-torrent/add-new-torrent.component.html
+++ b/client/src/app/add-new-torrent/add-new-torrent.component.html
@@ -53,6 +53,13 @@
             <li>
               <span class="icon is-small"><i class="fas fa-file" aria-hidden="true"></i></span>
               <span class="selected-files-name">{{ file.name }}</span>
+              <button
+                type="button"
+                class="delete is-small"
+                aria-label="Remove file"
+                [disabled]="saving"
+                (click)="removeFile($index)"
+              ></button>
             </li>
           }
         </ul>

--- a/client/src/app/add-new-torrent/add-new-torrent.component.html
+++ b/client/src/app/add-new-torrent/add-new-torrent.component.html
@@ -45,6 +45,20 @@
       </div>
     </div>
 
+    @if (selectedFiles.length > 1) {
+      <div class="field selected-files">
+        <label class="label">Selected files ({{ selectedFiles.length }})</label>
+        <ul>
+          @for (file of selectedFiles; track $index) {
+            <li>
+              <span class="icon is-small"><i class="fas fa-file" aria-hidden="true"></i></span>
+              <span class="selected-files-name">{{ file.name }}</span>
+            </li>
+          }
+        </ul>
+      </div>
+    }
+
     <div class="field">
       <label class="label">Magnet Link</label>
       <div class="control">

--- a/client/src/app/add-new-torrent/add-new-torrent.component.html
+++ b/client/src/app/add-new-torrent/add-new-torrent.component.html
@@ -20,15 +20,23 @@
 <div class="field">
   <div [hidden]="type !== 'torrent'">
     <div class="field">
-      <label class="label">Torrent file</label>
+      <label class="label">Torrent file(s)</label>
       <div class="file has-name">
         <label class="file-label">
-          <input class="file-input" type="file" name="resume" (change)="pickFile($event)" [disabled]="saving" />
+          <input
+            class="file-input"
+            type="file"
+            name="resume"
+            accept=".torrent"
+            multiple
+            (change)="pickFile($event)"
+            [disabled]="saving"
+          />
           <span class="file-cta">
             <span class="file-icon">
               <i class="fas fa-upload"></i>
             </span>
-            <span class="file-label"> Pick a torrent file... </span>
+            <span class="file-label"> Pick torrent file(s)... </span>
           </span>
           <span class="file-name">
             {{ fileName }}

--- a/client/src/app/add-new-torrent/add-new-torrent.component.scss
+++ b/client/src/app/add-new-torrent/add-new-torrent.component.scss
@@ -3,6 +3,35 @@
   width: 24em;
 }
 
+.selected-files {
+  margin-top: 0.5rem;
+
+  ul {
+    border: 1px solid #dbdbdb;
+    border-radius: 4px;
+    max-height: 12em;
+    overflow-y: auto;
+  }
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.85rem;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid #f0f0f0;
+    }
+  }
+
+  .selected-files-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
 .separator {
   display: flex;
   align-items: center;

--- a/client/src/app/add-new-torrent/add-new-torrent.component.scss
+++ b/client/src/app/add-new-torrent/add-new-torrent.component.scss
@@ -26,9 +26,16 @@
   }
 
   .selected-files-name {
+    flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .delete {
+    margin-left: auto;
+    flex-shrink: 0;
   }
 }
 

--- a/client/src/app/add-new-torrent/add-new-torrent.component.ts
+++ b/client/src/app/add-new-torrent/add-new-torrent.component.ts
@@ -174,10 +174,31 @@ export class AddNewTorrentComponent implements OnInit {
 
     this.selectedFiles = Array.from(files);
 
-    this.fileName =
-      this.selectedFiles.length === 1 ? this.selectedFiles[0].name : `${this.selectedFiles.length} files selected`;
+    this.updateFileName();
 
     this.checkFiles();
+  }
+
+  public removeFile(index: number): void {
+    this.selectedFiles = this.selectedFiles.filter((_, i) => i !== index);
+
+    this.updateFileName();
+
+    // With a single remaining file the per-torrent availability check applies
+    // again; with none it simply clears itself.
+    if (this.selectedFiles.length <= 1) {
+      this.checkFiles();
+    }
+  }
+
+  private updateFileName(): void {
+    if (this.selectedFiles.length === 0) {
+      this.fileName = null;
+    } else if (this.selectedFiles.length === 1) {
+      this.fileName = this.selectedFiles[0].name;
+    } else {
+      this.fileName = `${this.selectedFiles.length} files selected`;
+    }
   }
 
   public ok(): void {

--- a/client/src/app/add-new-torrent/add-new-torrent.component.ts
+++ b/client/src/app/add-new-torrent/add-new-torrent.component.ts
@@ -7,6 +7,7 @@ import { ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { NgClass } from '@angular/common';
 import { TorrentService } from '../torrent.service';
+import { catchError, concatMap, from, map, of, toArray } from 'rxjs';
 
 @Component({
   selector: 'app-add-new-torrent',
@@ -59,7 +60,7 @@ export class AddNewTorrentComponent implements OnInit {
   public excludeRegexError: string;
   public regexSelected: TorrentFileAvailability[];
 
-  private selectedFile: File | null = null;
+  public selectedFiles: File[] = [];
 
   public get category(): string {
     return this._category;
@@ -161,7 +162,7 @@ export class AddNewTorrentComponent implements OnInit {
   public changeType(type: 'torrent' | 'nzb'): void {
     this.type = type;
     this.fileName = null;
-    this.selectedFile = null;
+    this.selectedFiles = [];
   }
 
   public pickFile(evt: Event): void {
@@ -171,11 +172,10 @@ export class AddNewTorrentComponent implements OnInit {
       return;
     }
 
-    const file = files[0];
+    this.selectedFiles = Array.from(files);
 
-    this.fileName = file.name;
-
-    this.selectedFile = file;
+    this.fileName =
+      this.selectedFiles.length === 1 ? this.selectedFiles[0].name : `${this.selectedFiles.length} files selected`;
 
     this.checkFiles();
   }
@@ -184,9 +184,13 @@ export class AddNewTorrentComponent implements OnInit {
     this.saving = true;
     this.error = null;
 
+    // Manual file selection targets the files of a single torrent/magnet and cannot
+    // apply to a batch, so it is skipped when multiple torrent files are uploaded.
+    const isMultiTorrent = this.type === 'torrent' && !this.magnetLink && this.selectedFiles.length > 1;
+
     let downloadManualFiles: string = null;
 
-    if (this.downloadAction === 2) {
+    if (this.downloadAction === 2 && !isMultiTorrent) {
       const selectedFiles = [];
       for (const filePath in this.downloadFiles) {
         if (this.downloadFiles[filePath] === true) {
@@ -196,6 +200,7 @@ export class AddNewTorrentComponent implements OnInit {
 
       if (selectedFiles.length === 0) {
         this.error = 'No files have been selected to download';
+        this.saving = false;
         return;
       }
 
@@ -229,14 +234,16 @@ export class AddNewTorrentComponent implements OnInit {
             this.saving = false;
           },
         });
-      } else if (this.selectedFile) {
-        this.torrentService.uploadFile(this.selectedFile, torrent).subscribe({
+      } else if (this.selectedFiles.length === 1) {
+        this.torrentService.uploadFile(this.selectedFiles[0], torrent).subscribe({
           next: () => this.router.navigate(['/']),
           error: (err) => {
             this.error = err.error;
             this.saving = false;
           },
         });
+      } else if (this.selectedFiles.length > 1) {
+        this.uploadMultiple(this.selectedFiles, torrent);
       } else {
         this.error = 'No magnet or file uploaded';
         this.saving = false;
@@ -250,8 +257,8 @@ export class AddNewTorrentComponent implements OnInit {
             this.saving = false;
           },
         });
-      } else if (this.selectedFile) {
-        this.torrentService.uploadNzbFile(this.selectedFile, torrent).subscribe({
+      } else if (this.selectedFiles.length > 0) {
+        this.torrentService.uploadNzbFile(this.selectedFiles[0], torrent).subscribe({
           next: () => this.router.navigate(['/']),
           error: (err) => {
             this.error = err.error;
@@ -263,6 +270,37 @@ export class AddNewTorrentComponent implements OnInit {
         this.saving = false;
       }
     }
+  }
+
+  /**
+   * Uploads several torrent files sequentially with the same parameters.
+   * Each upload is queued independently; failures are collected and reported
+   * without aborting the remaining uploads.
+   */
+  private uploadMultiple(files: File[], torrent: Torrent): void {
+    from(files)
+      .pipe(
+        concatMap((file) =>
+          this.torrentService.uploadFile(file, torrent).pipe(
+            map(() => ({ name: file.name, error: null as string | null })),
+            catchError((err) => of({ name: file.name, error: (err?.error as string) ?? 'Upload failed' })),
+          ),
+        ),
+        toArray(),
+      )
+      .subscribe((results) => {
+        const failures = results.filter((r) => r.error);
+
+        if (failures.length === 0) {
+          this.router.navigate(['/']);
+          return;
+        }
+
+        this.saving = false;
+        this.error =
+          `${failures.length} of ${files.length} file(s) failed: ` +
+          failures.map((f) => `${f.name} (${f.error})`).join('; ');
+      });
   }
 
   public onPaste(): void {
@@ -300,8 +338,8 @@ export class AddNewTorrentComponent implements OnInit {
           this.saving = false;
         },
       });
-    } else if (this.selectedFile) {
-      this.torrentService.checkFiles(this.selectedFile).subscribe({
+    } else if (this.selectedFiles.length === 1) {
+      this.torrentService.checkFiles(this.selectedFiles[0]).subscribe({
         next: (result) => {
           this.saving = false;
           this.availableFiles = result;


### PR DESCRIPTION
Closes #1017

The Add Torrent form only accepted a single `.torrent` file at a time. This PR lets you select several `.torrent` files at once and queue them all with the same parameters (category, priority, include/exclude regex, minimum size, retries, lifetime, downloader, finished action, …).

### Changes

- The torrent file input now accepts multiple files (`multiple` + `accept=".torrent"`).
- Selected files are listed under the picker in a small scrollable list, each with a button to remove it from the selection before submitting.
- On submit, the files are uploaded sequentially — one queue entry per file — reusing the existing `UploadFile` endpoint. If one file fails the others still go through, and a summary of the failed files is shown instead of aborting the whole batch.
- The per-torrent manual file selection and the file availability check only run when a single file is selected, since they can't apply to a batch of torrents.

### Notes

- No backend changes.
- Single-file, magnet and NZB flows are unchanged.
