### PR TITLE
docs: fix stale "Internal Downloader" setting labels and clarify Bezzad per-download speed limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased
+## [Unreleased]
+### Fixed
+- Corrected the Download speed / Parallel connections / Connection Timeout setting labels that still referenced the removed "Internal Downloader" - these settings drive the Bezzad downloader. Clarified that the Bezzad download-speed limit applies per concurrent download, not globally.
 
 ## [2.0.140] - 2026-07-08
 ### Added

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This [downloader](https://github.com/bezzad/Downloader) can be used to download 
 
 It has the following options:
 
-- Download speed (in MB/s): This number indicates the speed in MB/s per download over all parallel downloads and chunks.
+- Download speed (in MB/s): Maximum speed in MB/s applied **per concurrent download** (aggregated across that download's chunks), not a global limit. The effective total ceiling is this value multiplied by the "Maximum parallel downloads" setting. For example, 40 MB/s with 2 parallel downloads is roughly 80 MB/s total, and 40 MB/s with 4 parallel downloads is roughly 160 MB/s total, so total throughput can appear higher than the number you set here. Set to 0 for unlimited.
 - Parallel connections per download: This number indicates how many parallel it will use per download. This can increase speed, recommended is no more than 8.
 - Parallel chunks per download: This number indicates in how many chunks each download is split, recommended is no more than 8.
 - Connection Timeout: This number indicates the timeout in milliseconds before a download chunk times out. It will retry each chunk 5 times before completely failing.
@@ -134,7 +134,7 @@ It has the following options:
 - Url: The full URL to your Aria2c service. This must end in /jsonrpc. A standard path is `http://192.168.10.2:6800/jsonrpc`.
 - Secret: Optional secret to connecto to your Aria2c service.
 
-If Aria2c is selected, none of the above options for `Internal Downloader` are used, you have to configure Aria2c manually.
+If Aria2c is selected, none of the above Bezzad options are used, you have to configure Aria2c manually.
 
 #### Symlink downloader
 

--- a/server/RdtClient.Data/Models/Internal/DbSettings.cs
+++ b/server/RdtClient.Data/Models/Internal/DbSettings.cs
@@ -108,11 +108,11 @@ public class DbSettingsDownloadClient
     [Description("Path where files are downloaded to on your host (i.e. D:\\Downloads). This path is used for *arr to find your downloads.")]
     public String MappedPath { get; set; } = @"C:\Downloads";
 
-    [DisplayName("Download speed (in MB/s) (only used for the Internal Downloader)")]
-    [Description("Maximum download speed in Megabytes per second. When set to 0 unlimited speed is used.")]
+    [DisplayName("Download speed (in MB/s) (only used for the Bezzad Downloader)")]
+    [Description("Maximum download speed in MB/s, applied per concurrent download (not a global limit). The effective total ceiling is this value multiplied by the 'Maximum parallel downloads' setting. For example, 40 with 2 parallel downloads is roughly 80 MB/s total, and 40 with 4 parallel downloads is roughly 160 MB/s total, so overall throughput can appear to exceed the value set here. When set to 0 unlimited speed is used.")]
     public Int32 MaxSpeed { get; set; } = 0;
 
-    [DisplayName("Parallel connections per download (only used for the Internal Downloader)")]
+    [DisplayName("Parallel connections per download (only used for the Bezzad Downloader)")]
     [Description("Maximum amount of parallel threads that are used to download a single file to your host. If set to 0 no parallel downloading will be done.")]
     public Int32 ParallelCount { get; set; } = 8;
 
@@ -124,7 +124,7 @@ public class DbSettingsDownloadClient
     [Description("Buffersize in bytes for the internal downloader, used to read data and write it to disk.")]
     public Int32 BufferSize { get; set; } = 4 * 1024 * 1024;
 
-    [DisplayName("Connection Timeout (only used for the Internal Downloader)")]
+    [DisplayName("Connection Timeout (only used for the Bezzad Downloader)")]
     [Description("Timeout in milliseconds before the downloader times out.")]
     public Int32 Timeout { get; set; } = 5000;
 


### PR DESCRIPTION
## Summary
- Relabel the **Download speed**, **Parallel connections per download** and **Connection Timeout** settings from `(only used for the Internal Downloader)` to `(only used for the Bezzad Downloader)`.
- Expand the **Download speed** (`MaxSpeed`) description to explain that the limit is applied **per concurrent download**, not globally, with two worked examples.
- Update the README Bezzad section to match, and drop a stale `Internal Downloader` reference in the Aria2c section.
- Add an `Unreleased` CHANGELOG entry (and close the `[Unreleased` bracket).

## Why
The Internal Downloader was removed (2.0.117 “migrated to the Bezzad downloader” / 2.0.119 “removed from the GUI”), but three settings still carried `(only used for the Internal Downloader)` labels. Those settings are in fact consumed by the Bezzad downloader (`BezzadDownloader.SetSettings` reads `MaxSpeed`, `ParallelCount`, `Timeout`), so the labels tell users the exact opposite of the truth — a reasonable reader on the default Bezzad client concludes the speed limit doesn’t apply to them.

There’s also a subtler point that isn’t documented anywhere: `MaximumBytesPerSecond` is set on **each per-file `BezzadDownloader` instance**, so with N concurrent downloads (`General:DownloadLimit`) the effective aggregate ceiling is `MaxSpeed × N`. In practice a user who sets 80 and runs 2+ parallel downloads sees total throughput sail past 80 and assumes the setting is broken. Relates to #887 (closed) — this documents the behaviour that issue was about.

## What this PR changes
- **`server/RdtClient.Data/Models/Internal/DbSettings.cs`** — relabel the three settings; rewrite the `MaxSpeed` description:
  > Maximum download speed in MB/s, applied per concurrent download (not a global limit). The effective total ceiling is this value multiplied by the 'Maximum parallel downloads' setting. For example, 40 with 2 parallel downloads is roughly 80 MB/s total, and 40 with 4 parallel downloads is roughly 160 MB/s total, so overall throughput can appear to exceed the value set here. When set to 0 unlimited speed is used.
- **`README.md`** — same clarification on the Bezzad “Download speed” bullet; fix the stale `Internal Downloader` mention under Aria2c.
- **`CHANGELOG.md`** — `Unreleased` → `Fixed` entry.

Docs/labels only — **no code or behaviour change**.

## Test plan
- [x] `git diff` reviewed — 3 files, 9 insertions / 7 deletions, no code paths touched.
- [x] Verified the three settings are read by `BezzadDownloader.SetSettings` (so “Bezzad Downloader” is the correct attribution).
- [x] Confirmed empirically that with `MaxSpeed=80` and 2 parallel downloads, aggregate throughput exceeds 80 MB/s while no single file exceeds the cap (the behaviour the new wording describes).

If you’d prefer different wording (or to leave the MB vs MiB nuance — the value is multiplied by 1024×1024 internally — out of scope), happy to adjust.
