### PR TITLE
fix: No files found are eligible for import in Radarr

### DIFF
--- a/server/RdtClient.Data/Data/TorrentData.cs
+++ b/server/RdtClient.Data/Data/TorrentData.cs
@@ -122,6 +122,7 @@ public class TorrentData(DataContext dataContext, ILogger<TorrentData>? logger =
             return;
         }
 
+        dbTorrent.ClientKind = torrent.ClientKind;
         dbTorrent.RdName = torrent.RdName;
         dbTorrent.RdSize = torrent.RdSize;
         dbTorrent.RdHost = torrent.RdHost;


### PR DESCRIPTION
Root cause: TorrentData.UpdateRdData() copied every other Rd* field from the in-memory torrent to the DB, but never copied ClientKind. That meant ClientKind stayed NULL in the database for every torrent, regardless of provider.

Impact: QBittorrent.cs's GetContentPathName() has a TorBox-specific branch that only fires when torrent.ClientKind == Provider.TorBox, returning the correct  folder name (filename without extension) that matches TorBox's on-disk layout for single-file torrents. Since ClientKind was always NULL, this branch never fired, and RDT-Client reported the wrong content path to Radarr/Sonarr -- causing the "No files found eligible for import..."

I was able to test this with TorBox.

Resolves: [#978](https://github.com/rogerfar/rdt-client/issues/978)